### PR TITLE
Fix field `overwrite` inconsistencies, make `field.label` required

### DIFF
--- a/plugins/module_utils/errors.py
+++ b/plugins/module_utils/errors.py
@@ -36,5 +36,5 @@ class ServerError(APIError):
 
 
 class AccessDeniedError(APIError):
-    DEFAULT_MSG = "Token invalid or Vault not in scope for Service Account"
+    DEFAULT_MSG = "Token invalid or access to Vault not granted by token."
     STATUS_CODE = 403

--- a/plugins/module_utils/specs.py
+++ b/plugins/module_utils/specs.py
@@ -109,9 +109,9 @@ API_CONFIG = dict(
 
 # User-configurable attributes for one or more fields on an Item
 FIELD = dict(
-    label=dict(type="str"),
+    label=dict(type="str", required=True),
     value=dict(type="str", no_log=True),
-    overwrite=dict(type="bool", default=False),
+    overwrite=dict(type="bool", default=True),
     section=dict(type="str"),
     field_type=dict(
         type="str",

--- a/plugins/modules/generic_item.py
+++ b/plugins/modules/generic_item.py
@@ -18,7 +18,7 @@ requirements:
 notes:
 short_description: Creates a customizable 1Password Item
 description:
-  - Create or update an Item in a Vault using the Service Account associated with the JWT.
+  - Create or update an Item in a Vault.
   - Fully customizable using the Fields option
   - B(NOTE): When I(state=upsert) be aware that any Item fields without labels are removed during the update process.
 options:
@@ -61,6 +61,7 @@ options:
     suboptions:
       label:
         type: str
+        required: true
         description: The name of the field
       value:
         type: str
@@ -69,13 +70,13 @@ options:
             - If C(generate_value) is C(true), this attribute is ignored.
       overwrite:
         type: bool
-        default: no
+        default: yes
         choices:
             - yes
             - no
         description:
-            - Always replaces the field's value on the server when updating the Item.
-            - Ignore changes to the field's value after creating the item.
+            - Always replace the field's value when updating the Item.
+            - Preserve the field value returned by 1Password if not undefined. 
             - B(NOTE): Only valid on fields with a non-empty C(label).
       section:
         type: str

--- a/plugins/modules/item_info.py
+++ b/plugins/modules/item_info.py
@@ -8,18 +8,17 @@ author:
   - 1Password (@1Password)
 requirements:
 notes:
-short_description: Gets infomation on an 1Password Item
+short_description: Returns information about a 1Password Item
 description:
-  - Get an Item in a Vault using the Service Account associated with the JWT.
   - The name or ID of an item can be given.
-  - It is possible to specify a particular field.
-  - If no vaults are specified, every vault associated to the Service Account will be searched through.
+  - It is possible to return information about a specific field instead of an item.
+  - If no vaults are specified, the module searches every vault accessible by the API token.
 options:
   item:
     type: str
     required: True
     description:
-      - Name or ID of the item as displayed in the 1Password UI.
+      - Name or ID of the item as shown in the 1Password UI.
   field: str
     type: str
     description:
@@ -27,8 +26,8 @@ options:
   vault: str
     type: str
     description:
-      - Name or ID of the Vault in which the Item is located.
-      - If not specified, will look through every Vault associated to the Service Account. 
+      - Name or ID of the Vault in which the Item is stored.
+      - If not specified, the module searches through every vault accessible by the API token. 
 extends_documentation_fragment:
   - onepassword.connect.api_params
 '''

--- a/tests/integration/targets/generic_item/tasks/tests.yml
+++ b/tests/integration/targets/generic_item/tasks/tests.yml
@@ -3,7 +3,7 @@
 - name: Create new item
   generic_item:
     state: created
-    title: Example Item
+    title: Example Item - ANSIBLE TEST
     category: server
     tags:
       - exampleTag
@@ -26,7 +26,7 @@
 - name: Upsert item
   generic_item:
     state: upserted
-    title: Test Item UPDATED
+    title: Example Item UPDATED - ANSIBLE TEST
     uuid: "{{ result['op_item']['id'] }}"
     category: server
     tags:
@@ -49,7 +49,7 @@
   assert:
     that:
       - updated_1p_item.op_item.id == result.op_item.id
-      - updated_1p_item.op_item.title == 'Test Item UPDATED'
+      - updated_1p_item.op_item.title == 'Example Item UPDATED - ANSIBLE TEST'
 
 - name: Assert tags updated
   assert:

--- a/tests/integration/targets/item_info/tasks/tests.yml
+++ b/tests/integration/targets/item_info/tasks/tests.yml
@@ -3,7 +3,7 @@
 - name: Create a test item
   generic_item:
     state: created
-    title: Test Item
+    title: Test Item - ANSIBLETEST
     category: server
     tags:
       - exampleTag
@@ -15,7 +15,7 @@
 - name: Create a second test item
   generic_item:
     state: created
-    title: Test Item 2
+    title: Test Item 2 - ANSIBLETEST
     category: server
     tags:
       - exampleTag


### PR DESCRIPTION
# Changes
- Fixes `overwrite` default to be `true`. All fields are changed when `state:upserted` unless `overwrite: no` is set
- The `field.label` is now required. Empty field labels complicate generating item diffs.
- Update documentation with clearer explanations for `overwrite` and the API Token.
