### PR TITLE
Remove invalid tags from galaxy.yml

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -18,7 +18,7 @@ license:
 
 license_file: 'LICENSE.md'
 
-tags: ['onepassword', 'secrets', '1password', 'onepasswordconnect', '1passwordconnect']
+tags: ['onepassword', 'secrets', 'onepasswordconnect', 'connect']
 
 dependencies: {}
 


### PR DESCRIPTION
Per galaxy.yml spec, tags may not start with a number: https://docs.ansible.com/ansible/latest/dev_guide/collections_galaxy_meta.html#collections-galaxy-meta