### PR TITLE
Address linting issues with the galaxy manifest.

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -25,7 +25,7 @@ repository: https://github.com/1Password/ansible-onepasswordconnect-collection
 documentation: https://github.com/1Password/ansible-onepasswordconnect-collection
 
 # The URL to the homepage of the collection/project
-homepage: https://1password.com
+homepage: https://1password.com/secrets
 
 # The URL to the collection issue tracker
 issues: https://github.com/1Password/ansible-onepasswordconnect-collection/issues

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,12 +9,9 @@ version: "1.0.0"
 readme: README.md
 
 authors:
-- 1Password <support@1password.com>
+  - 1Password <support@1password.com>
 
 description: Modules for managing and reading 1Password Vaults with 1Password Connect.
-
-license:
-  - MIT
 
 license_file: 'LICENSE.md'
 
@@ -25,7 +22,7 @@ dependencies: {}
 repository: https://github.com/1Password/ansible-onepasswordconnect-collection
 
 # The URL to any online docs
-documentation: https://github.com/1Password/ansible-onepasswordconnect-collection/README.md
+documentation: https://github.com/1Password/ansible-onepasswordconnect-collection
 
 # The URL to the homepage of the collection/project
 homepage: https://1password.com
@@ -35,4 +32,4 @@ issues: https://github.com/1Password/ansible-onepasswordconnect-collection/issue
 
 # A list of file glob-like patterns used to filter any files or directories that should not be included in the build
 # artifact.
-build_ignore: ['scripts', '.venv', '.*']
+build_ignore: ['scripts', '.venv', '.*', 'tests']


### PR DESCRIPTION
Fixes:
- Removes duplicate `license` key because `license_file` serves the same purpose
- Updates documentation link
- Excludes test files from build artifact