### PR TITLE
Fix the path to the collection test script in the Makefile 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,10 @@ curVersion := $$(sed -n -E 's/^version: ([0-9]+\.[0-9]+\.[0-9]+)$/\1/p' galaxy.y
 
 test: test/unit ## Run unit tests in a Docker container
 test/unit:
-	$(SCRIPTS_DIR)/run_tests.sh units
+	$(SCRIPTS_DIR)/run-tests.sh units
 
 test/integration:	## Run integration tests inside a Docker container
-	$(SCRIPTS_DIR)/run_tests.sh integration
+	$(SCRIPTS_DIR)/run-tests.sh integration
 
 build: clean	## Build collection artifact
 	ansible-galaxy collection build --output-path dist/


### PR DESCRIPTION
## Fixes

Resolves issue where running the test commands from the Makefile (`test/unit` & `test/integration`) would return an error about an invalid path.

The filename for the test runner changed from `run_tests.sh` to `run-tests.sh`, but the change was not reflected in the Makefile.