### PR TITLE
Add support for API_CREDENTIAL item type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 1Password Connect Ansible Collection
 
-The 1Password Connect collection contains modules that interact with 1Password Connect. The modules communicate with 1Password Connect to support Vault Item create/read/update/delete operations.
+The 1Password Connect collection contains modules that interact with your 1Password Connect API server. The modules communicate with 1Password Connect to support Vault Item create/read/update/delete operations.
 
 ## Table of Contents
 
@@ -19,7 +19,7 @@ The 1Password Connect collection contains modules that interact with 1Password C
 ### Requirements
 - ansible >= 2.9
 - Python >= 3.6.0
-- 1Password Connect
+- 1Password Connect >= 1.0.0
     
 ## Installation
 

--- a/plugins/module_utils/const.py
+++ b/plugins/module_utils/const.py
@@ -36,8 +36,6 @@ class FieldType:
 
 
 class ItemType:
-
-    # Item Types
     LOGIN = "LOGIN"
     PASSWORD = "PASSWORD"
     SERVER = "SERVER"
@@ -47,6 +45,7 @@ class ItemType:
     WIRELESS_ROUTER = "WIRELESS_ROUTER"
     BANK_ACCOUNT = "BANK_ACCOUNT"
     EMAIL_ACCOUNT = "EMAIL_ACCOUNT"
+    API_CREDENTIAL = "API_CREDENTIAL"
 
     @classmethod
     def choices(cls):

--- a/plugins/modules/generic_item.py
+++ b/plugins/modules/generic_item.py
@@ -39,12 +39,12 @@ options:
     description:
       - Unique ID for a single Item.
       - Ignored if C(state) is C(present) and the item doesn't exist.
-      - If C(state) is C(present) and c(uuid) is NOT defined, the module will try to find an item using C(name).
+      - If C(state) is C(present) and C(uuid) is NOT defined, the module will try to find an item using C(name).
         If an item cannot be found, a new item is created with the C(name) value and the old item is not changed.
   category:
     type: str
     default: password
-    description: Instructs 1Password to configure the Item using the specified template.
+    description: Applies the selected category template to the item.
     choices:
       - login
       - password
@@ -55,11 +55,12 @@ options:
       - wireless_router
       - bank_account
       - email_account
+      - api_credential
   urls:
     type: list
     elements: str
     description:
-      - Stores one or more URLs on an item
+      - Store one or more URLs on an item
       - URLs are clickable in the 1Password UI
   favorite:
     type: bool


### PR DESCRIPTION
Resolves #16 

Change will allow users to specify `category: api_credential` when defining a vault item in a playbook. This ensures we remain aligned with the other 1Password Connect SDKs and connectors.