### PR TITLE
Add more supported item type choices

### DIFF
--- a/plugins/module_utils/const.py
+++ b/plugins/module_utils/const.py
@@ -2,7 +2,6 @@ from __future__ import (absolute_import, division, print_function)
 
 __metaclass__ = type
 
-
 # Server-generated name for the Notes field
 NOTES_FIELD_LABEL = "notesPlain"
 
@@ -46,6 +45,14 @@ class ItemType:
     BANK_ACCOUNT = "BANK_ACCOUNT"
     EMAIL_ACCOUNT = "EMAIL_ACCOUNT"
     API_CREDENTIAL = "API_CREDENTIAL"
+    CREDIT_CARD = "CREDIT_CARD"
+    MEMBERSHIP = "MEMBERSHIP"
+    PASSPORT = "PASSPORT"
+    OUTDOOR_LICENSE = "OUTDOOR_LICENSE"
+    DRIVER_LICENSE = "DRIVER_LICENSE"
+    IDENTITY = "IDENTITY"
+    REWARD_PROGRAM = "REWARD_PROGRAM"
+    SOCIAL_SECURITY_NUMBER = "SOCIAL_SECURITY_NUMBER"
 
     @classmethod
     def choices(cls):

--- a/plugins/modules/generic_item.py
+++ b/plugins/modules/generic_item.py
@@ -50,12 +50,20 @@ options:
       - password
       - server
       - database
+      - api_credential
       - software_license
       - secure_note
       - wireless_router
       - bank_account
       - email_account
-      - api_credential
+      - credit_card
+      - membership
+      - passport
+      - outdoor_license
+      - driver_license
+      - identity
+      - reward_program
+      - social_security_number
   urls:
     type: list
     elements: str


### PR DESCRIPTION
## Summary

Harmonizes Ansible collection with other integrations that support all item types. Using an item type is not required, but we should still have a consistent experience across all Connect integrations.

Fixes #22 