### PR TITLE
WIP: Change item type default to `API_CREDENTIAL`

### DIFF
--- a/plugins/module_utils/const.py
+++ b/plugins/module_utils/const.py
@@ -32,7 +32,11 @@ class FieldType:
 
     @classmethod
     def choices(cls):
-        return [v for k, v in vars(cls).items() if k.isupper() and not k.startswith("_")]
+        return [
+            v.lower()
+            for k, v in vars(cls).items()
+            if k.isupper() and not k.startswith("_")
+        ]
 
 
 class ItemType:
@@ -49,4 +53,8 @@ class ItemType:
 
     @classmethod
     def choices(cls):
-        return [v for k, v in vars(cls).items() if k.isupper() and not k.startswith("_")]
+        return [
+            v.lower()
+            for k, v in vars(cls).items()
+            if k.isupper() and not k.startswith("_")
+        ]

--- a/plugins/module_utils/specs.py
+++ b/plugins/module_utils/specs.py
@@ -36,8 +36,8 @@ def op_item():
         ),
         category=dict(
             type="str",
-            default="password",
-            choices=list(map(str.lower, const.ItemType.choices()))
+            default=const.ItemType.API_CREDENTIAL.lower(),
+            choices=const.ItemType.choices(),
         ),
         urls=dict(
             type="list",
@@ -118,7 +118,7 @@ FIELD = dict(
     field_type=dict(
         type="str",
         default="string",
-        choices=list(map(str.lower, const.FieldType.choices()))
+        choices=const.FieldType.choices()
     ),
     generate_value=dict(
         type="str",

--- a/plugins/modules/generic_item.py
+++ b/plugins/modules/generic_item.py
@@ -46,6 +46,7 @@ options:
     default: api_credential
     description: 
       - Applies the selected category template to the item. Other 1Password clients use category templates to help organize fields when rendering an item. 
+      - The category cannot be changed after creating an item. To change an item's category, recreate it with the new category.
     choices:
       - login
       - password

--- a/plugins/modules/generic_item.py
+++ b/plugins/modules/generic_item.py
@@ -43,8 +43,9 @@ options:
         If an item cannot be found, a new item is created with the C(name) value and the old item is not changed.
   category:
     type: str
-    default: password
-    description: Applies the selected category template to the item.
+    default: api_credential
+    description: 
+      - Applies the selected category template to the item. Other 1Password clients use category templates to help organize fields when rendering an item. 
     choices:
       - login
       - password


### PR DESCRIPTION
_This PR is another pre-requisite for #20_ 

## Summary

Switches the default item type to `API_CREDENTIAL`, which has no required fields and offers the most flexibility when creating an item with custom fields.

Using`LOGIN` or `PASSWORD` as the item type default value introduced hidden field requirements around "username" and "password" fields. The `API_CREDENTIAL` type is more or less equivalent to an empty item.

## Impacts
~~**This may impact users if the items in their playbooks do not have a category value**. In practice, a login field may turn into an api_credentials field if a customer updates to the latest collection version and does not explicitly define the item type as `login`.~~ 

Edit: **Item categories cannot be changed after creating an item.** Items created after updating to the collection version that includes this change will have the item category set to `api_credential` if none is provided.
