### PR TITLE
DRAFT: Fix field_purpose assignment when item type is `PASSWORD` or `LOGIN`.

### DIFF
--- a/plugins/module_utils/const.py
+++ b/plugins/module_utils/const.py
@@ -19,6 +19,12 @@ GENERATE_VALUE_CHOICES = (
     GENERATE_ON_CREATE,
 )
 
+# Field purposes when using certain item categories
+PURPOSE_PASSWORD = "PASSWORD"
+PURPOSE_USERNAME = "USERNAME"
+PURPOSE_NOTES = "NOTES"
+PURPOSE_NONE = ""
+
 
 class FieldType:
     STRING = "STRING"

--- a/plugins/module_utils/errors.py
+++ b/plugins/module_utils/errors.py
@@ -15,6 +15,14 @@ class MissingVaultID(Error):
     DEFAULT_MSG = "A Vault ID is required to use this module."
 
 
+class PrimaryPasswordAlreadyExists(Error):
+    DEFAULT_MSG = "Only one primary password may exist for an item."
+
+
+class PrimaryUsernameAlreadyExists(Error):
+    DEFAULT_MSG = "Only one primary username may exist for an item."
+
+
 class APIError(Error):
     DEFAULT_MSG = "Error while communicating with Secrets Server"
     STATUS_CODE = 400

--- a/plugins/module_utils/errors.py
+++ b/plugins/module_utils/errors.py
@@ -15,12 +15,16 @@ class MissingVaultID(Error):
     DEFAULT_MSG = "A Vault ID is required to use this module."
 
 
+class PrimaryUsernameAlreadyExists(Error):
+    DEFAULT_MSG = "Only one primary username may exist for an item."
+
+
 class PrimaryPasswordAlreadyExists(Error):
     DEFAULT_MSG = "Only one primary password may exist for an item."
 
 
-class PrimaryUsernameAlreadyExists(Error):
-    DEFAULT_MSG = "Only one primary username may exist for an item."
+class PrimaryPasswordUndefined(Error):
+    DEFAULT_MSG = "This item category requires at least one concealed field."
 
 
 class APIError(Error):

--- a/plugins/module_utils/fields.py
+++ b/plugins/module_utils/fields.py
@@ -28,15 +28,16 @@ def create(field_params, previous_fields=None):
     if not previous_fields:
         previous_fields = []
 
+    # The Notes field should not be editable by Ansible,
+    # and the old value is preserved if it exists
+    notes_field = _get_field_by_label(
+        previous_fields, const.NOTES_FIELD_LABEL
+    )
+    if notes_field:
+        yield notes_field
+
     for params in field_params:
         if params.get("label") == const.NOTES_FIELD_LABEL:
-            # The Notes field should not be editable by Ansible,
-            # and the old value is preserved if it exists
-            existing_notes_field = _get_field_by_label(
-                previous_fields, const.NOTES_FIELD_LABEL
-            )
-            if existing_notes_field:
-                yield existing_notes_field
             continue
 
         should_generate_value = False

--- a/plugins/module_utils/specs.py
+++ b/plugins/module_utils/specs.py
@@ -118,7 +118,8 @@ FIELD = dict(
     field_type=dict(
         type="str",
         default="string",
-        choices=const.FieldType.choices()
+        choices=const.FieldType.choices(),
+        aliases=["type"]
     ),
     generate_value=dict(
         type="str",

--- a/plugins/module_utils/vault.py
+++ b/plugins/module_utils/vault.py
@@ -54,13 +54,14 @@ def create_item(params, api_client, check_mode=False):
 
     op_item = assemble_item(
         vault_id=vault_id,
-        category=params["category"],
+        category=params["category"].upper(),
         title=params.get("name"),
         urls=params.get("urls"),
         favorite=params.get("favorite"),
         fieldset=item_fields,
         tags=params.get("tags")
     )
+
     if check_mode:
         op_item["fields"] = fields.flatten_fieldset(op_item.get("fields"))
         return True, op_item
@@ -94,7 +95,7 @@ def update_item(params, original_item, api_client, check_mode=False):
 
     updated_item = assemble_item(
         vault_id=vault_id,
-        category=params["category"],
+        category=params["category"].upper(),
         title=params.get("name"),
         urls=params.get("urls"),
         favorite=params.get("favorite"),
@@ -105,7 +106,6 @@ def update_item(params, original_item, api_client, check_mode=False):
     updated_item.update({
         "id": original_item["id"],
     })
-
     changed = recursive_diff(original_item, updated_item)
 
     if not bool(changed):
@@ -172,23 +172,23 @@ def assemble_item(
     :rtype: dict
     """
 
-    sections = {}
-
     item = {
         "title": title,
         "vault": {"id": vault_id},
-        "category": category.upper(),
+        "category": category,
         "urls": [{"href": url} for url in urls or []],
         "tags": tags or [],
         "fields": [],
         "favorite": bool(favorite)
     }
 
+    sections = {}
+
     if fieldset is not None:
         for field in fieldset:
             if field.get("section"):
                 # Squash sections with identical names
-                # but continue respecting name casing
+                # with case-sensitive lookup
                 section_name = field["section"].strip()
 
                 section = sections.setdefault(
@@ -200,12 +200,11 @@ def assemble_item(
 
             field.update({
                 "section": {"id": section.id} if section else None,
-                "purpose": _get_field_purpose(category, field["type"])
+                "purpose": _get_field_purpose(field, category)
             })
 
             item["fields"].append(field)
 
-    # Remap unique sections to expected schema format
     if sections:
         item["sections"] = [
             {"id": section.id, "label": section.label}
@@ -215,9 +214,36 @@ def assemble_item(
     return item
 
 
-def _get_field_purpose(item_type, field_type):
-    if item_type in (const.ItemType.LOGIN, const.ItemType.PASSWORD,):
-        # TODO: Username purpose handling?
-        if field_type == const.FieldType.CONCEALED:
-            return "PASSWORD"
-        return ""
+def _get_field_purpose(field, item_category):
+    """
+    Assign a field purpose based on the item category and the field's type.
+
+    PURPOSE_USERNAME and PURPOSE_PASSWORD apply to the last seen field in the item
+    that matches the criteria in this function.
+    :param field: Field definition
+    :param item_category: ItemType The category assigned to the item for this field
+    :return: string
+    """
+    field_label = field.get("label")
+    field_type = field.get("type", "").upper()
+
+    if not field_label:
+        return const.PURPOSE_NONE
+
+    # Only expect an exact match for the notes field
+    if field_type == const.FieldType.STRING and field_label == const.NOTES_FIELD_LABEL:
+        return const.PURPOSE_NOTES
+
+    field_label = field_label.lower()
+
+    if item_category == const.ItemType.LOGIN:
+        if field_type == const.FieldType.STRING and field_label == "username":
+            return const.PURPOSE_USERNAME
+        if field_type == const.FieldType.CONCEALED and field_label == "password":
+            return const.PURPOSE_PASSWORD
+
+    if item_category == const.ItemType.PASSWORD:
+        if field_type == const.FieldType.CONCEALED and field_label == "password":
+            return const.PURPOSE_PASSWORD
+
+    return const.PURPOSE_NONE

--- a/plugins/module_utils/vault.py
+++ b/plugins/module_utils/vault.py
@@ -221,18 +221,18 @@ def _prepare_fields(fields, item_category):
     for field in fields:
         field_purpose = _get_field_purpose(field, item_category)
 
-        # Items types that assign purpose to certain fields cannot
-        # apply the purpose to more than 1 field.
         if field_purpose == const.PURPOSE_USERNAME:
             if primary_username_set:
+                # Primary username may only be set once per item
                 raise errors.PrimaryUsernameAlreadyExists(
-                    f"Item type {item_category} may only have one 'username' field")
+                    f"Item type {item_category} may only have one (1) 'username' field"
+                )
             primary_username_set = True
 
         if field_purpose == const.PURPOSE_PASSWORD:
             if primary_password_set:
                 raise errors.PrimaryPasswordAlreadyExists(
-                    f"Item type {item_category} may only have one 'password' field")
+                    f"Item type {item_category} may only have one (1) 'password' field")
             primary_password_set = True
 
         field.update({
@@ -240,6 +240,11 @@ def _prepare_fields(fields, item_category):
         })
 
         yield field
+
+    if item_category == const.ItemType.PASSWORD and not primary_password_set:
+        raise errors.PrimaryPasswordUndefined(
+            f"Item type {item_category} requires a 'concealed' field named 'password'."
+        )
 
 
 def _get_field_purpose(field, item_category):

--- a/plugins/modules/generic_item.py
+++ b/plugins/modules/generic_item.py
@@ -44,11 +44,19 @@ options:
   category:
     type: str
     default: api_credential
-    description: 
-      - Applies the selected category template to the item. Other 1Password clients use category templates to help organize fields when rendering an item. 
-      - The category cannot be changed after creating an item. To change an item's category, recreate it with the new category.
-      - If the category is C(login) or C(password) and the item has a field named C(password), that field will be the primary password when the item is displayed in 1Password clients.
-      - If the category is C(login) and the item has a field named C(username), that field becomes the primary username when the item is displayed in 1Password clients.
+    description:
+      - >
+        Applies the selected category template to the item. Other 1Password clients use category templates to help
+        organize fields when rendering an item.
+      - >
+        The category cannot be changed after creating an item.
+        To change the category, recreate the item with the new category
+      - >
+        If the category is C(login) or C(password) and the item has a field named C(password),
+        that field will be the primary password when the item is displayed in 1Password clients.
+      - >
+        If the category is C(login) and the item has a field named C(username),
+        that field becomes the primary username when the item is displayed in 1Password clients.
     choices:
       - login
       - password
@@ -99,7 +107,13 @@ options:
       field_type:
         type: str
         default: string
-        description: Sets expected value type for the field.
+        aliases:
+        - type
+        description:
+            - Sets expected value type for the field.
+            - >
+                If C(generic_item.category) is C(login) or C(password), the field with type C(concealed) and
+                named C(password) becomes the item's primary password.
         choices:
           - string
           - email
@@ -229,7 +243,9 @@ EXAMPLES = '''
 
 RETURN = '''
 op_item:
-  description: Dictionary containing Item properties or an empty dictionary if I(state=absent). See 1Password Connect API specs for complete structure.
+  description: >
+    Dictionary containing Item properties or an empty dictionary if I(state=absent).
+    See 1Password Connect API for complete structure.
   type: complex
   returned: always
   contains:

--- a/plugins/modules/generic_item.py
+++ b/plugins/modules/generic_item.py
@@ -47,6 +47,8 @@ options:
     description: 
       - Applies the selected category template to the item. Other 1Password clients use category templates to help organize fields when rendering an item. 
       - The category cannot be changed after creating an item. To change an item's category, recreate it with the new category.
+      - If the category is C(login) or C(password) and the item has a field named C(password), that field will be the primary password when the item is displayed in 1Password clients.
+      - If the category is C(login) and the item has a field named C(username), that field becomes the primary username when the item is displayed in 1Password clients.
     choices:
       - login
       - password

--- a/plugins/modules/item_info.py
+++ b/plugins/modules/item_info.py
@@ -158,8 +158,9 @@ def _get_item(op, item, vault_id):
 
 
 def _get_item_field(item, selected_field):
+    selected_field = fields.normalize_label(selected_field)
     for field in item["fields"]:
-        if field["label"] == selected_field:
+        if fields.normalize_label(field["label"]) == selected_field:
             return field["value"]
     raise errors.NotFoundError
 

--- a/tests/integration/targets/generic_item/tasks/tests.yml
+++ b/tests/integration/targets/generic_item/tasks/tests.yml
@@ -14,7 +14,7 @@
     tags:
       - exampleTag
     fields:
-      - label: mypassword
+      - label: password
         field_type: concealed
         generate_value: always
         generator_recipe:
@@ -23,38 +23,41 @@
       - label: "{{ field_wont_exist_after_update }}"
         value: example
 
-      - label: password
+      - label: password99
         field_type: concealed
         value: this1sap4s5word
 
       - label: Generated String
         generate_value: on_create
-  register: result
+  register: original
 
+# NOTE: Connect server <= 1.2.0 changes name of the field with purpose==PASSWORD
+#   to `password`
 - name: Assert item properties returned
   assert:
     that:
-      - result.changed
-      - result.op_item is defined
-      - result.op_item.id is defined
-      - result.op_item.fields.mypassword is defined
-      - "result.op_item.fields.password.purpose == 'PASSWORD'"
+      - original.changed
+      - original.op_item is defined
+      - original.op_item.id is defined
+      - original.op_item.fields.mypassword is not defined
+      - original.op_item.fields.password is defined
+      - "original.op_item.fields.password.purpose == 'PASSWORD'"
 
 - set_fact:
-    created_item_ids: "{{ created_item_ids + [ result.op_item.id ] }}"
-    updated_item_title: "{{ result.op_item.title }} UPDATED"
+    created_item_ids: "{{ created_item_ids + [ original.op_item.id ] }}"
+    updated_item_title: "{{ original.op_item.title }} UPDATED"
 
 - name: Upsert item
   generic_item:
     state: present
     title: "{{ updated_item_title }}"
-    uuid: "{{ result.op_item.id }}"
+    uuid: "{{ original.op_item.id }}"
     category: password
     tags:
       - exampleTag
       - another-tag
     fields:
-      - label: mypassword
+      - label: password
         field_type: concealed
         generate_value: on_create
         generator_recipe:
@@ -63,19 +66,15 @@
       - label: Generated String
         generate_value: always
         section: "Collaboration Details"
-
-      - label: password
-        field_type: concealed
-        value: password
   register: updated_1p_item
 
 - name: Assert updated item properties
   assert:
     that:
       - updated_1p_item.changed
-      - updated_1p_item.op_item.id == result.op_item.id
+      - updated_1p_item.op_item.id == original.op_item.id
       - updated_1p_item.op_item.title == updated_item_title
-      - updated_1p_item.op_item.fields.mypassword.value == result.op_item.fields.mypassword.value
+      - updated_1p_item.op_item.fields.password.value == original.op_item.fields.password.value
       - field_wont_exist_after_update not in updated_1p_item.op_item.fields
 
 - name: Assert tags updated

--- a/tests/integration/targets/generic_item/tasks/tests.yml
+++ b/tests/integration/targets/generic_item/tasks/tests.yml
@@ -1,20 +1,34 @@
 ---
 
+- set_fact:
+    field_wont_exist_after_update: "transitoryExampleLabel"
+    original_item_title: "Example Item - ANSIBLE TEST {{ 9999 | random }}"
+    created_item_ids: []
+    default_tempalte: "API_CREDENTIAL"
+
 - name: Create new item
   generic_item:
     state: present
-    title: "Example Item - ANSIBLE TEST {{ 9999 | random }}"
-    category: server
+    title: "{{ original_item_title }}"
+    category: password
     tags:
       - exampleTag
     fields:
       - label: mypassword
         field_type: concealed
-        generate_value: on_create
+        generate_value: always
         generator_recipe:
           include_digits: no
-      - label: Test
-        value: Hello
+
+      - label: "{{ field_wont_exist_after_update }}"
+        value: example
+
+      - label: password
+        field_type: concealed
+        value: this1sap4s5word
+
+      - label: Generated String
+        generate_value: on_create
   register: result
 
 - name: Assert item properties returned
@@ -24,8 +38,10 @@
       - result.op_item is defined
       - result.op_item.id is defined
       - result.op_item.fields.mypassword is defined
+      - "result.op_item.fields.password.purpose == 'PASSWORD'"
 
 - set_fact:
+    created_item_ids: "{{ created_item_ids + [ result.op_item.id ] }}"
     updated_item_title: "{{ result.op_item.title }} UPDATED"
 
 - name: Upsert item
@@ -33,7 +49,7 @@
     state: present
     title: "{{ updated_item_title }}"
     uuid: "{{ result.op_item.id }}"
-    category: server
+    category: password
     tags:
       - exampleTag
       - another-tag
@@ -43,10 +59,14 @@
         generate_value: on_create
         generator_recipe:
           include_digits: no
-      - label: Different label this time
-        value: Hello
-      - label: Another field
-        value: qwertyuiop[]
+
+      - label: Generated String
+        generate_value: always
+        section: "Collaboration Details"
+
+      - label: password
+        field_type: concealed
+        value: password
   register: updated_1p_item
 
 - name: Assert updated item properties
@@ -56,6 +76,7 @@
       - updated_1p_item.op_item.id == result.op_item.id
       - updated_1p_item.op_item.title == updated_item_title
       - updated_1p_item.op_item.fields.mypassword.value == result.op_item.fields.mypassword.value
+      - field_wont_exist_after_update not in updated_1p_item.op_item.fields
 
 - name: Assert tags updated
   assert:
@@ -65,7 +86,27 @@
     - exampleTag
     - another-tag
 
+- name: Create item with default template
+  generic_item:
+    state: present
+    title: Using Default Template
+    fields:
+      - label: Generated String
+        generate_value: always
+        section: "Collaboration Details"
+  register: item_with_default_template
+
+- name: Assert item with default template created
+  assert:
+    that:
+      - item_with_default_template.changed
+      - 'item_with_default_template.op_item.category == "API_CREDENTIAL"'
+
+- set_fact:
+    created_item_ids: "{{ created_item_ids + [ item_with_default_template.op_item.id ] }}"
+
 - name: Cleanup
   generic_item:
     state: absent
-    uuid: "{{result['op_item']['id']}}"
+    uuid: "{{ item }}"
+  with_items: "{{ created_item_ids }}"

--- a/tests/unit/plugins/module_utils/test_item_assembly.py
+++ b/tests/unit/plugins/module_utils/test_item_assembly.py
@@ -211,31 +211,36 @@ FIELD_PURPOSE_TESTCASES = [
         const.ItemType.API_CREDENTIAL, "xyz", const.FieldType.STRING, const.PURPOSE_NONE, id="default_field_purpose"
     ),
     pytest.param(
-        const.ItemType.PASSWORD, "password", const.FieldType.STRING, const.PURPOSE_NONE, id="wrong_field_type_for_primary_password"
+        const.ItemType.PASSWORD, "password", const.FieldType.CONCEALED, const.PURPOSE_PASSWORD,
+        id="primary_password_for_password_item"
     ),
     pytest.param(
-        const.ItemType.PASSWORD, "password", const.FieldType.CONCEALED, const.PURPOSE_PASSWORD, id="primary_password_for_password_item"
+        const.ItemType.SERVER, "password", const.FieldType.CONCEALED, const.PURPOSE_NONE,
+        id="item_type_does_not_use_password_field_purpose"
     ),
     pytest.param(
-        const.ItemType.SERVER, "password", const.FieldType.CONCEALED, const.PURPOSE_NONE, id="item_type_does_not_use_password_field_purpose"
+        const.ItemType.SERVER, "username", const.FieldType.STRING, const.PURPOSE_NONE,
+        id="item_type_does_not_use_username_field_purpose"
     ),
     pytest.param(
-        const.ItemType.SERVER, "username", const.FieldType.STRING, const.PURPOSE_NONE, id="item_type_does_not_use_username_field_purpose"
+        const.ItemType.LOGIN, "password", const.FieldType.CONCEALED, const.PURPOSE_PASSWORD,
+        id="primary_password_for_login_item",
     ),
     pytest.param(
-        const.ItemType.LOGIN, "password", const.FieldType.CONCEALED, const.PURPOSE_PASSWORD, id="primary_password_for_login_item",
+        const.ItemType.LOGIN, "username", const.FieldType.STRING, const.PURPOSE_USERNAME,
+        id="primary_username_for_login_item",
     ),
     pytest.param(
-        const.ItemType.LOGIN, "username", const.FieldType.STRING, const.PURPOSE_USERNAME, id="primary_username_for_login_item",
+        const.ItemType.LOGIN, "password", const.FieldType.STRING, const.PURPOSE_NONE,
+        id="wrong_field_type_for_login_item_primary_password",
     ),
     pytest.param(
-        const.ItemType.LOGIN, "password", const.FieldType.STRING, const.PURPOSE_NONE, id="wrong_field_type_for_login_item_primary_password",
+        const.ItemType.LOGIN, "username", const.FieldType.TOTP, const.PURPOSE_NONE,
+        id="wrong_field_type_for_login_item_primary_username",
     ),
     pytest.param(
-        const.ItemType.LOGIN, "username", const.FieldType.TOTP, const.PURPOSE_NONE, id="wrong_field_type_for_login_item_primary_username",
-    ),
-    pytest.param(
-        const.ItemType.API_CREDENTIAL, const.NOTES_FIELD_LABEL, const.FieldType.STRING, const.PURPOSE_NOTES, id="notes_field_is_assigned_notes_purpose"
+        const.ItemType.API_CREDENTIAL, const.NOTES_FIELD_LABEL, const.FieldType.STRING, const.PURPOSE_NOTES,
+        id="notes_field_is_assigned_notes_purpose"
     ),
 ]
 
@@ -304,4 +309,29 @@ def test_username_and_password_purpose_is_limited_to_one_field():
             vault_id="1234xyz",
             category=const.ItemType.LOGIN,
             fieldset=two_primary_username_fields
+        )
+
+
+def test_password_item_type_requires_primary_password():
+    """Assert at least one field with type `concealed` is defined
+    when creating item with type ItemType.PASSWORD.
+    """
+    fields = [
+        {
+            "label": "Garage Code",
+            "type": const.FieldType.STRING,
+            "value": "1234",
+        },
+        {
+            "label": "Anniversary",
+            "type": const.FieldType.MONTH_YEAR,
+            "value": "12/10",
+        },
+    ]
+
+    with pytest.raises(errors.PrimaryPasswordUndefined):
+        vault.assemble_item(
+            vault_id="1234xyz",
+            category=const.ItemType.PASSWORD,
+            fieldset=fields
         )

--- a/tests/unit/plugins/module_utils/test_item_crud.py
+++ b/tests/unit/plugins/module_utils/test_item_crud.py
@@ -10,7 +10,7 @@ from ansible_collections.onepassword.connect.plugins.module_utils import vault, 
 def test_create_item(mocker):
     params = {
         "vault_id": "Abc123",
-        "category": const.ItemType.PASSWORD,
+        "category": const.ItemType.API_CREDENTIAL,
         "name": "My New Item",
         "favorite": True
     }
@@ -33,7 +33,7 @@ def test_check_mode(mocker):
     mock_api = mocker.Mock()
     create_item_params = {
         "vault_id": vault_id,
-        "category": const.ItemType.PASSWORD,
+        "category": const.ItemType.API_CREDENTIAL,
         "name": "My New Item",
         "favorite": True
     }


### PR DESCRIPTION
## Summary

Fixes #20 

This PR updates how Ansible assigns a field's `purpose` when creating a `PASSWORD` or `LOGIN` item. The `purpose` assignments help the Connect server set "Primary Password" and "Primary Username" for item types that have "primary" field support.

### Password Items

The **Password** item type requires one concealed field with the `PASSWORD` purpose. 

Previously, we did not check for whether a Password item had a concealed field before sending it to the Connect server. If that was the case, users would receive vague validation errors from Connect server.

Instead, the Ansible `generic_item` module now asserts there is 1 concealed field named `password` when the item type 
is `PASSWORD`. [1]

### Login Items

In addition to a required `PASSWORD` purpose field, the **Login** item has an optional `username` field. The module now checks for a string field named `username`, and if one is found, the module adds the `USERNAME` purpose. [2]

## Impacts

**_Breaking changes_** ⚠️ 
- Creating an item with `type: password` without a **concealed** field named `password` raises an error
- If the item type is `password` and there are multiple **concealed** fields named `password`, Ansible raises an error
- If the item type is `login` and there are multiple **string** fields named `username`, Ansible raises an error.

### Workarounds
[1] The module explicitly looks for a field named "password" because the Connect server <=1.2.0 reassigns the name of the primary password field to "password." 