### PR TITLE
Improve Python2 and Python3.5 compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GIT_BRANCH := $(shell git symbolic-ref --short HEAD)
 WORKTREE_CLEAN := $(shell git status --porcelain 1>/dev/null 2>&1; echo $$?)
 SCRIPTS_DIR := $(CURDIR)/scripts
 
-curVersion := $$(sed -n -E 's/^version: "([0-9]+\.[0-9]+\.[0-9]+)"$/\1/p' galaxy.yml)
+curVersion := $$(sed -n -E 's/^version: "([0-9]+\.[0-9]+\.[0-9]+)"$$/\1/p' galaxy.yml)
 
 test: test/unit ## Run unit tests in a Docker container
 test/unit:

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -4,9 +4,9 @@ __metaclass__ = type
 
 import json
 import sys
-from urllib import parse
 
 from ansible.module_utils.urls import fetch_url
+from ansible.module_utils.six.moves.urllib.parse import urlencode, quote, urlunparse, urlparse
 from ansible_collections.onepassword.connect.plugins.module_utils import errors, const
 
 
@@ -142,7 +142,7 @@ class OnePassword:
 
 
 def build_endpoint(hostname, path, params=None, api_version=None):
-    url_parts = list(parse.urlparse(hostname))
+    url_parts = list(urlparse(hostname))
 
     if not api_version:
         api_version = OnePassword.API_VERSION
@@ -150,11 +150,11 @@ def build_endpoint(hostname, path, params=None, api_version=None):
     # Path _may_ have a space in it if client passes item name, for example
     url_parts[2] = "{api_version}/{path}".format(
         api_version=api_version,
-        path=parse.quote(path.strip('/'))
+        path=quote(path.strip('/'))
     )
     if params:
-        url_parts[4] = parse.urlencode(params)
-    return parse.urlunparse(url_parts)
+        url_parts[4] = urlencode(params)
+    return urlunparse(url_parts)
 
 
 def raise_for_error(response_info):

--- a/plugins/module_utils/errors.py
+++ b/plugins/module_utils/errors.py
@@ -8,7 +8,7 @@ class Error(Exception):
 
     def __init__(self, message=None):
         self.message = message or self.DEFAULT_MSG
-        super().__init__(message)
+        super(Error, self).__init__(message)
 
 
 class MissingVaultID(Error):
@@ -33,7 +33,7 @@ class APIError(Error):
 
     def __init__(self, status_code=None, message=None):
         self.status_code = status_code or self.STATUS_CODE
-        super().__init__(message)
+        super(APIError, self).__init__(message)
 
 
 class NotFoundError(APIError):

--- a/plugins/module_utils/fields.py
+++ b/plugins/module_utils/fields.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import unicodedata
+from ansible.module_utils.six import text_type
 from ansible_collections.onepassword.connect.plugins.module_utils import const
 
 
@@ -86,7 +87,7 @@ def normalize_label(raw_str):
     if not raw_str:
         return None
 
-    unicode_normalized = unicodedata.normalize("NFKD", raw_str)
+    unicode_normalized = unicodedata.normalize("NFKD", text_type(raw_str))
     return unicode_normalized.strip()
 
 

--- a/plugins/module_utils/vault.py
+++ b/plugins/module_utils/vault.py
@@ -225,14 +225,14 @@ def _prepare_fields(fields, item_category):
             if primary_username_set:
                 # Primary username may only be set once per item
                 raise errors.PrimaryUsernameAlreadyExists(
-                    f"Item type {item_category} may only have one (1) 'username' field"
+                    "Item type {0} may only have one (1) 'username' field".format(item_category)
                 )
             primary_username_set = True
 
         if field_purpose == const.PURPOSE_PASSWORD:
             if primary_password_set:
                 raise errors.PrimaryPasswordAlreadyExists(
-                    f"Item type {item_category} may only have one (1) 'password' field")
+                    "Item type {0} may only have one (1) 'password' field".format(item_category))
             primary_password_set = True
 
         field.update({
@@ -243,7 +243,7 @@ def _prepare_fields(fields, item_category):
 
     if item_category == const.ItemType.PASSWORD and not primary_password_set:
         raise errors.PrimaryPasswordUndefined(
-            f"Item type {item_category} requires a 'concealed' field named 'password'."
+            "Item type {0} requires a 'concealed' field named 'password'.".format(item_category)
         )
 
 

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -35,7 +35,7 @@ PATH_TO_PACKAGES="$(git rev-parse --show-toplevel)"
 
 # Use a python3-compatible container
 # https://docs.ansible.com/ansible/latest/dev_guide/testing_integration.html#container-images
-DOCKER_IMG="ubuntu1804"
+DOCKER_IMG="default"
 
 function _cleanup() {
   rm -r "${TMP_DIR_PATH}"

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -1,0 +1,3 @@
+scripts/prepare-release.sh shellcheck:SC2086
+plugins/modules/generic_item.py validate-modules:missing-gplv3-license
+plugins/modules/item_info.py validate-modules:missing-gplv3-license

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,0 +1,3 @@
+scripts/prepare-release.sh shellcheck:SC2086
+plugins/modules/generic_item.py validate-modules:missing-gplv3-license
+plugins/modules/item_info.py validate-modules:missing-gplv3-license

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,0 +1,3 @@
+scripts/prepare-release.sh shellcheck:SC2086
+plugins/modules/generic_item.py validate-modules:missing-gplv3-license
+plugins/modules/item_info.py validate-modules:missing-gplv3-license

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -1,0 +1,3 @@
+scripts/prepare-release.sh shellcheck:SC2086
+plugins/modules/generic_item.py validate-modules:missing-gplv3-license
+plugins/modules/item_info.py validate-modules:missing-gplv3-license

--- a/tests/unit/plugins/module_utils/test_item_crud.py
+++ b/tests/unit/plugins/module_utils/test_item_crud.py
@@ -15,11 +15,11 @@ def test_create_item(mocker):
         "favorite": True
     }
 
+    mock_item = dict(params)
+    mock_item["id"] = "abc123xyz9325"
+
     mock_api = mocker.Mock()
-    mock_api.create_item.return_value = {
-        "id": "abc123xyz9325",
-        **params
-    }
+    mock_api.create_item.return_value = mock_item
 
     modified, new_item = vault.create_item(params, mock_api)
 
@@ -44,11 +44,8 @@ def test_check_mode(mocker):
     item["vault"] = {"id": create_item_params["vault_id"]}
     item["id"] = "987654321"
 
-    update_params = {
-        **{k: v for k, v in create_item_params.items() if k != "vault_id"},
-        "vault_id": vault_id,
-        "name": "UPDATED Title",
-    }
+    update_params = dict(create_item_params)
+    update_params.update({"vault_id": vault_id, "name": "UPDATED Title"})
 
     modified, updated_item = vault.update_item(update_params, item, mock_api, check_mode=True)
     assert modified


### PR DESCRIPTION
## Summary

The RedHat Automation Hub has more requirements around compatibility than Ansible Galaxy. We needed to improve compatibility with Python versions prior to 3.6 because of customer expectations for runtime support.

We can revisit the compatibility changes once minimum versions are bumped up.

## Changes
- Use ansible's [built-in](https://docs.ansible.com/ansible/latest/dev_guide/developing_python_3.html#import-ansible-s-bundled-python-six-library) `six` library when working with `urllib`
- Use "old style" `super()` calls
- Remove f-strings, replace with [py2.6-compatible](https://docs.ansible.com/ansible/latest/dev_guide/developing_python_3.html#use-str-format-for-python-2-6-compatibility) `.format()`
- str / bytes compatibility
- Introduce exclusions for sanity test false-positives in the `tests/sanity` folder.