### PR TITLE
Fix OTP field type label and value.

### DIFF
--- a/plugins/module_utils/const.py
+++ b/plugins/module_utils/const.py
@@ -31,7 +31,7 @@ class FieldType:
     EMAIL = "EMAIL"
     CONCEALED = "CONCEALED"
     URL = "URL"
-    TOTP = "TOTP"
+    OTP = "OTP"
     DATE = "DATE"
     MONTH_YEAR = "MONTH_YEAR"
 

--- a/plugins/modules/generic_item.py
+++ b/plugins/modules/generic_item.py
@@ -119,7 +119,7 @@ options:
           - email
           - concealed
           - url
-          - totp
+          - otp
           - date
           - month_year
       generate_value:


### PR DESCRIPTION
# Summary

Resolves #46 

This PR resolves an issue when trying to create an item with an OTP field. The server expects "OTP", not "TOTP" as a field type. 

I've changed the internal enum value to point to `OTP` and updated the relevant module documentation. This shouldn't be a breaking change because it's fixing an existing issue 😄 