### PR TITLE
Exclude GPL License check during ansible sanity tests

### DIFF
--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -1,3 +1,4 @@
 scripts/prepare-release.sh shellcheck:SC2086
 plugins/modules/generic_item.py validate-modules:missing-gplv3-license
 plugins/modules/item_info.py validate-modules:missing-gplv3-license
+plugins/modules/field_info.py validate-modules:missing-gplv3-license

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,3 +1,4 @@
 scripts/prepare-release.sh shellcheck:SC2086
 plugins/modules/generic_item.py validate-modules:missing-gplv3-license
 plugins/modules/item_info.py validate-modules:missing-gplv3-license
+plugins/modules/field_info.py validate-modules:missing-gplv3-license

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,3 +1,4 @@
 scripts/prepare-release.sh shellcheck:SC2086
 plugins/modules/generic_item.py validate-modules:missing-gplv3-license
 plugins/modules/item_info.py validate-modules:missing-gplv3-license
+plugins/modules/field_info.py validate-modules:missing-gplv3-license

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -1,3 +1,4 @@
 scripts/prepare-release.sh shellcheck:SC2086
 plugins/modules/generic_item.py validate-modules:missing-gplv3-license
 plugins/modules/item_info.py validate-modules:missing-gplv3-license
+plugins/modules/field_info.py validate-modules:missing-gplv3-license


### PR DESCRIPTION
# Summary

Adds the new `field_info` module to the list of files excluded from the `validate-modules:missing-gplv3-license` test.

This change follows the `ansible-test` [Ignore File Format](https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/ignores.html#ignore-file-format).

We don't include the GPLv2 header in our files because we opted to use the MIT license for our collection instead.