### PR TITLE
Add required meta/runtime.yml for Ansible Galaxy compat

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,2 @@
+---
+requires_ansible: '>=2.9'


### PR DESCRIPTION
Ansible Galaxy silently began requiring a meta/runtime.yml file when uploading a collection. This requirement came into effect around July 2021

See also:
[1] https://issues.redhat.com/browse/AAH-538
[2] https://github.com/ansible/galaxy-importer/pull/122