### PR TITLE
Add GitHub action for Ansible sanity tests

### DIFF
--- a/.github/workflows/ansible-sanity.yml
+++ b/.github/workflows/ansible-sanity.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   ansible-sanity:
-    name: Ansible Linter (v${{ matrix.ansible }})
+    name: Ansible Linter (v${{ matrix.ansible }}, py${{ matrix.python }})
     strategy:
       matrix:
         ansible: ["2.9", "2.10", "2.11", "2.12"]

--- a/.github/workflows/ansible-sanity.yml
+++ b/.github/workflows/ansible-sanity.yml
@@ -1,0 +1,54 @@
+---
+name: ansible-sanity
+
+on:
+  pull_request:
+    branches:
+      - "main"
+
+env:
+  MIN_PYTHON_VERSION: "3.8"
+  # defines where ansible will look for the collection
+  # must be a sub-directory of ansible_collections/
+  COLLECTION_PATH: ansible_collections/onepassword/connect
+
+jobs:
+  ansible-sanity:
+    name: Ansible Linter (v${{ matrix.ansible }})
+    strategy:
+      matrix:
+        ansible: ["2.9", "2.10", "2.11", "2.12"]
+        python: ["3.6", "3.7", "3.8", "3.9"]
+        exclude:
+          # python3.9 unsupported by ansible2.9
+          - ansible: "2.9"
+            python: "3.9"
+          # ansible 2.12 requires python3.8 or newer
+          # https://github.com/ansible/ansible/issues/72668
+          - ansible: "2.12"
+            python: "3.6"
+          - ansible: "2.12"
+            python: "3.7"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ env.COLLECTION_PATH }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+            path: ${{ env.COLLECTION_PATH }}
+
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+            python-version: ${{env.MIN_PYTHON_VERSION}}
+
+      - name: Install ansible-core stable-${{ matrix.ansible }}
+        run: pip install https://github.com/ansible/ansible/archive/stable-${{ matrix.ansible }}.tar.gz --disable-pip-version-check
+
+      # running with docker-in-docker
+      # the installed ansible-test command will know which container to use
+      # for each ansible version
+      - name: Run ansible-test sanity (v${{ matrix.ansible }}, python${{ matrix.python }})
+        run: ansible-test sanity -v --docker --redact --python ${{ matrix.python }}

--- a/.github/workflows/ansible-tests.yml
+++ b/.github/workflows/ansible-tests.yml
@@ -1,5 +1,5 @@
 ---
-name: ansible-sanity
+name: ansible-tests
 
 on:
   pull_request:
@@ -8,6 +8,9 @@ on:
 
 env:
   MIN_PYTHON_VERSION: "3.8"
+  # arbitrarily choosing the latest stable version to run ansible-test units
+  # running ansible-test units for each ansible+python version isn't necessary
+  ANSIBLE_FOR_UNIT_TESTS: "2.11"
   # defines where ansible will look for the collection
   # must be a sub-directory of ansible_collections/
   COLLECTION_PATH: ansible_collections/onepassword/connect
@@ -52,3 +55,26 @@ jobs:
       # for each ansible version
       - name: Run ansible-test sanity (v${{ matrix.ansible }}, python${{ matrix.python }})
         run: ansible-test sanity -v --docker --redact --python ${{ matrix.python }}
+
+  ansible-units:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ env.COLLECTION_PATH }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: ${{ env.COLLECTION_PATH }}
+
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{env.MIN_PYTHON_VERSION}}
+
+      - name: Install ansible-core stable-${{ env.ANSIBLE_FOR_UNIT_TESTS }}
+        run: pip install https://github.com/ansible/ansible/archive/stable-${{ env.ANSIBLE_FOR_UNIT_TESTS }}.tar.gz --disable-pip-version-check
+
+      - name: Run ansible-test units
+        run: ansible-test units -v --docker --redact --python ${{ env.MIN_PYTHON_VERSION }}

--- a/.github/workflows/ansible-tests.yml
+++ b/.github/workflows/ansible-tests.yml
@@ -9,7 +9,7 @@ on:
 env:
   MIN_PYTHON_VERSION: "3.8"
   # arbitrarily choosing the latest stable version to run ansible-test units
-  # running ansible-test units for each ansible+python version isn't necessary
+  # running 'ansible-test units' for each ansible+python version isn't necessary
   ANSIBLE_FOR_UNIT_TESTS: "2.11"
   # defines where ansible will look for the collection
   # must be a sub-directory of ansible_collections/
@@ -48,7 +48,10 @@ jobs:
             python-version: ${{env.MIN_PYTHON_VERSION}}
 
       - name: Install ansible-core stable-${{ matrix.ansible }}
-        run: pip install https://github.com/ansible/ansible/archive/stable-${{ matrix.ansible }}.tar.gz --disable-pip-version-check
+        run: |
+          pip install \
+          https://github.com/ansible/ansible/archive/stable-${{ matrix.ansible }}.tar.gz \
+          --disable-pip-version-check
 
       # running with docker-in-docker
       # the installed ansible-test command will know which container to use

--- a/.github/workflows/ansible-tests.yml
+++ b/.github/workflows/ansible-tests.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   ansible-sanity:
-    name: Ansible Linter (v${{ matrix.ansible }}, py${{ matrix.python }})
+    name: Ansible Sanity Test (v${{ matrix.ansible }}, py${{ matrix.python }})
     strategy:
       matrix:
         ansible: ["2.9", "2.10", "2.11", "2.12"]

--- a/plugins/modules/field_info.py
+++ b/plugins/modules/field_info.py
@@ -186,7 +186,8 @@ def main():
     result = {"field": {}}
 
     module = AnsibleModule(
-        argument_spec=specs.op_field_info()
+        argument_spec=specs.op_field_info(),
+        supports_check_mode=True
     )
 
     api_client = api.create_client(module)

--- a/tests/unit/plugins/module_utils/test_item_assembly.py
+++ b/tests/unit/plugins/module_utils/test_item_assembly.py
@@ -235,7 +235,7 @@ FIELD_PURPOSE_TESTCASES = [
         id="wrong_field_type_for_login_item_primary_password",
     ),
     pytest.param(
-        const.ItemType.LOGIN, "username", const.FieldType.TOTP, const.PURPOSE_NONE,
+        const.ItemType.LOGIN, "username", const.FieldType.OTP, const.PURPOSE_NONE,
         id="wrong_field_type_for_login_item_primary_username",
     ),
     pytest.param(


### PR DESCRIPTION
# Summary

Adds automated `ansible-test sanity` and `ansible-test units` GitHub workflows. The `ansible-test sanity` job is run for each version of `ansible-core` supported by the collection. 

"Sanity" tests are equivalent to lint tests, and do not require a Connect server to run.

**Supported `ansible-core` versions**:
- 2.9 (⚠️ deprecated beginning **December 2022**)
- 2.10
- 2.11
- 2.12 

The GitHub action will run a sanity test suite for each ansible version listed above.

### References

This workflow was heavily inspired by [T-Systems-MMS/ansible-collection-icinga-directory](https://github.com/T-Systems-MMS/ansible-collection-icinga-director/blob/35ce15a5529d9a3f23dcfb671c02147747475813/.github/workflows/main.yml).