### PR TITLE
Add AH tag

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -15,7 +15,7 @@ description: Modules for managing and reading 1Password Vaults with 1Password Co
 
 license_file: 'LICENSE.md'
 
-tags: ['onepassword', 'secrets', 'onepasswordconnect', 'connect']
+tags: ['security', 'onepassword', 'secrets', 'onepasswordconnect', 'connect']
 
 dependencies: {}
 


### PR DESCRIPTION
Adding an Ansible Automation Hub tag ('security') to add compliance with the Automation Hub guidelines.

Available AH tags to use: 
* application
* cloud
* database
* infrastructure
* linux
* monitoring
* networking
* security
* storage
* tools
* windows
