### PR TITLE
improved handling errors

### DIFF
--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -52,14 +52,10 @@ class OnePassword:
         response_body = {}
 
         resp, info = fetch_url(self._module, **fetch_kwargs)
-        if type(resp) is not HTTPError:
+        if info.get("status") == 200:
             try:
                 response_body = json.loads(resp.read().decode("utf-8"))
             except (AttributeError, ValueError):
-                if info.get("status") == 204:
-                    # No Content response
-                    return {}
-
                 msg = "Server returned error with invalid JSON: {err}".format(
                     err=info.get("msg", "<Undefined error>")
                 )


### PR DESCRIPTION
Description:
Bad request 400 returns when fetch existing item by title. [Detailed description.](https://1password.community/discussion/123474/connect-server-api-shows-unable-to-find-existing-span-for-request-then-400-bad-request-in-logs)

Solution:
Distinguish success responses by status code.