### PR TITLE
Add 204 as a valid status code for DELETE operation in api.py

### DIFF
--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -52,14 +52,15 @@ class OnePassword:
         response_body = {}
 
         resp, info = fetch_url(self._module, **fetch_kwargs)
-        if info.get("status") == 200:
-            try:
-                response_body = json.loads(resp.read().decode("utf-8"))
-            except (AttributeError, ValueError):
-                msg = "Server returned error with invalid JSON: {err}".format(
-                    err=info.get("msg", "<Undefined error>")
-                )
-                return self._module.fail_json(msg=msg)
+        if info.get("status") in [200, 204]:
+            if info.get("status") == 200:
+                try:
+                    response_body = json.loads(resp.read().decode("utf-8"))
+                except (AttributeError, ValueError):
+                    msg = "Server returned error with invalid JSON: {err}".format(
+                        err=info.get("msg", "<Undefined error>")
+                    )
+                    return self._module.fail_json(msg=msg)
         else:
             raise_for_error(info)
 


### PR DESCRIPTION
As per the 1Password Connect Server API reference, the expected status code for DELETE operation is 204. api.py would always expect a 200 status code, so a successful DELETE operation incorrectly registered as a failure. This commit adds 204 as a success status code. Ref: https://developer.1password.com/docs/connect/connect-api-reference/#delete-an-item