### PR TITLE
Update ci scripts

### DIFF
--- a/.github/workflows/ansible-tests.yml
+++ b/.github/workflows/ansible-tests.yml
@@ -7,7 +7,7 @@ on:
       - "main"
 
 env:
-  MIN_PYTHON_VERSION: "3.9"
+  MIN_PYTHON_VERSION: "3.8"
   # arbitrarily choosing the latest stable version to run ansible-test units
   # running 'ansible-test units' for each ansible+python version isn't necessary
   ANSIBLE_FOR_UNIT_TESTS: "2.15"

--- a/.github/workflows/ansible-tests.yml
+++ b/.github/workflows/ansible-tests.yml
@@ -10,7 +10,7 @@ env:
   MIN_PYTHON_VERSION: "3.8"
   # arbitrarily choosing the latest stable version to run ansible-test units
   # running 'ansible-test units' for each ansible+python version isn't necessary
-  ANSIBLE_FOR_UNIT_TESTS: "2.11"
+  ANSIBLE_FOR_UNIT_TESTS: "2.15"
   # defines where ansible will look for the collection
   # must be a sub-directory of ansible_collections/
   COLLECTION_PATH: ansible_collections/onepassword/connect
@@ -20,18 +20,15 @@ jobs:
     name: Ansible Sanity Test (v${{ matrix.ansible }}, py${{ matrix.python }})
     strategy:
       matrix:
-        ansible: ["2.9", "2.10", "2.11", "2.12"]
-        python: ["3.6", "3.7", "3.8", "3.9"]
+        ansible: ["2.13", "2.14", "2.15"]
+        python: ["3.8", "3.9", "3.10", "3.11"]
         exclude:
-          # python3.9 unsupported by ansible2.9
-          - ansible: "2.9"
-            python: "3.9"
-          # ansible 2.12 requires python3.8 or newer
-          # https://github.com/ansible/ansible/issues/72668
-          - ansible: "2.12"
-            python: "3.6"
-          - ansible: "2.12"
-            python: "3.7"
+          - ansible: "2.13"
+            python: "3.11"
+          - ansible: "2.14"
+            python: "3.8"
+          - ansible: "2.15"
+            python: "3.8"
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/ansible-tests.yml
+++ b/.github/workflows/ansible-tests.yml
@@ -38,12 +38,12 @@ jobs:
         working-directory: ${{ env.COLLECTION_PATH }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
             path: ${{ env.COLLECTION_PATH }}
 
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
             python-version: ${{env.MIN_PYTHON_VERSION}}
 
@@ -67,12 +67,12 @@ jobs:
         working-directory: ${{ env.COLLECTION_PATH }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: ${{ env.COLLECTION_PATH }}
 
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{env.MIN_PYTHON_VERSION}}
 

--- a/.github/workflows/ansible-tests.yml
+++ b/.github/workflows/ansible-tests.yml
@@ -7,7 +7,7 @@ on:
       - "main"
 
 env:
-  MIN_PYTHON_VERSION: "3.8"
+  MIN_PYTHON_VERSION: "3.9"
   # arbitrarily choosing the latest stable version to run ansible-test units
   # running 'ansible-test units' for each ansible+python version isn't necessary
   ANSIBLE_FOR_UNIT_TESTS: "2.15"

--- a/.github/workflows/ansible-tests.yml
+++ b/.github/workflows/ansible-tests.yml
@@ -7,7 +7,7 @@ on:
       - "main"
 
 env:
-  MIN_PYTHON_VERSION: "3.9"
+  PYTHON_VERSION: "3.9"
   # arbitrarily choosing the latest stable version to run ansible-test units
   # running 'ansible-test units' for each ansible+python version isn't necessary
   ANSIBLE_FOR_UNIT_TESTS: "2.15"
@@ -43,7 +43,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-            python-version: ${{env.MIN_PYTHON_VERSION}}
+            python-version: ${{env.PYTHON_VERSION}}
 
       - name: Install ansible-core stable-${{ matrix.ansible }}
         run: |
@@ -72,10 +72,10 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{env.MIN_PYTHON_VERSION}}
+          python-version: ${{env.PYTHON_VERSION}}
 
       - name: Install ansible-core stable-${{ env.ANSIBLE_FOR_UNIT_TESTS }}
         run: pip install https://github.com/ansible/ansible/archive/stable-${{ env.ANSIBLE_FOR_UNIT_TESTS }}.tar.gz --disable-pip-version-check
 
       - name: Run ansible-test units
-        run: ansible-test units -v --docker --redact --python ${{ env.MIN_PYTHON_VERSION }}
+        run: ansible-test units -v --docker --redact --python ${{ env.PYTHON_VERSION }}

--- a/.github/workflows/ansible-tests.yml
+++ b/.github/workflows/ansible-tests.yml
@@ -7,7 +7,7 @@ on:
       - "main"
 
 env:
-  MIN_PYTHON_VERSION: "3.8"
+  MIN_PYTHON_VERSION: "3.9"
   # arbitrarily choosing the latest stable version to run ansible-test units
   # running 'ansible-test units' for each ansible+python version isn't necessary
   ANSIBLE_FOR_UNIT_TESTS: "2.15"
@@ -19,6 +19,7 @@ jobs:
   ansible-sanity:
     name: Ansible Sanity Test (v${{ matrix.ansible }}, py${{ matrix.python }})
     strategy:
+      # https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
       matrix:
         ansible: ["2.13", "2.14", "2.15"]
         python: ["3.8", "3.9", "3.10", "3.11"]

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - id: is_release_branch_without_pr
         name: Find matching PR
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -42,7 +42,7 @@ jobs:
     name: Create Release Pull Request
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Parse release version
         id: get_version

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -14,12 +14,12 @@ After reading this document, you will:
 
 > If you have already installed a supported version of Ansible, you can skip to the [Clone the Repo](#clone-the-repo) step.
 
-This collection requires **Python v3.6 or greater**. If you don't have Python installed, consider using [pyenv](https://github.com/pyenv/pyenv) to install the supported Python runtime.
+This collection requires **Python v3.8 or greater**. If you don't have Python installed, consider using [pyenv](https://github.com/pyenv/pyenv) to install the supported Python runtime.
 
 
 Current Ansible-core and Ansible version supported:
-- `ansible-core`: **2.11.***
-- `ansible`: **>=4.0,<5**
+- `ansible-core`: **2.15***
+- `ansible`: **>=6.x**
 
 We recommend installing Ansible in a `virtualenv` created specifically for this project. 
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,14 @@
-Copyright (c) 2020, 1Password
+Copyright (C) 2020  1Password & Agilebits (@1Password)
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/USAGEGUIDE.md
+++ b/USAGEGUIDE.md
@@ -15,7 +15,7 @@
 * [Testing](#testing)
 
 ### Requirements
-- Python >= 3.6.0
+- Python >= 3.8.0
 - 1Password Connect >= 1.0.0
     
 #### Supported Ansible Versions

--- a/USAGEGUIDE.md
+++ b/USAGEGUIDE.md
@@ -21,8 +21,8 @@
 #### Supported Ansible Versions
 
 This collection has been tested against the following Ansible versions:
-* `ansible-core`: >=2.9, 2.11, 2.12
-* `ansible`: >=4.0, <5.0
+* `ansible-core`: >=2.13
+* `ansible`: >=6.x
 
 ## Installation
 

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.13'
+requires_ansible: '>=2.15'

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.15'
+requires_ansible: '>=2.13'

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.9'
+requires_ansible: '>=2.13'

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -9,7 +9,6 @@ import base64
 import sys
 import re
 
-from urllib.error import HTTPError
 from ansible.module_utils.urls import fetch_url
 from ansible.module_utils.six.moves.urllib.parse import urlencode, quote, urlunparse, urlparse
 from ansible_collections.onepassword.connect.plugins.module_utils import errors, const

--- a/plugins/modules/field_info.py
+++ b/plugins/modules/field_info.py
@@ -1,7 +1,20 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# (c) 2021, 1Password & Agilebits (@1Password)
+#  Copyright (C) 2021  1Password & Agilebits (@1Password)
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
 
@@ -83,7 +96,7 @@ field:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.onepassword.connect.plugins.module_utils import specs, api, errors, fields, util
+from ansible_collections.onepassword.connect.plugins.module_utils import specs, api, errors, fields, util  # pylint: disable=unused-import
 from ansible.module_utils.common.text.converters import to_native
 
 

--- a/plugins/modules/field_info.py
+++ b/plugins/modules/field_info.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-#  Copyright (C) 2021  1Password & Agilebits (@1Password)
+#  Copyright (C) 2020  1Password & Agilebits (@1Password)
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/plugins/modules/field_info.py
+++ b/plugins/modules/field_info.py
@@ -82,7 +82,6 @@ field:
         sample: "fb3b40ac85f5435d26e"
 '''
 
-from ansible.module_utils.six import text_type
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.onepassword.connect.plugins.module_utils import specs, api, errors, fields, util
 from ansible.module_utils.common.text.converters import to_native

--- a/plugins/modules/generic_item.py
+++ b/plugins/modules/generic_item.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-#  Copyright (C) 2021  1Password & Agilebits (@1Password)
+#  Copyright (C) 2020  1Password & Agilebits (@1Password)
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/plugins/modules/generic_item.py
+++ b/plugins/modules/generic_item.py
@@ -1,7 +1,20 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# (c) 2021, 1Password & Agilebits (@1Password)
+#  Copyright (C) 2021  1Password & Agilebits (@1Password)
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
 

--- a/plugins/modules/item_info.py
+++ b/plugins/modules/item_info.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-#  Copyright (C) 2021  1Password & Agilebits (@1Password)
+#  Copyright (C) 2020  1Password & Agilebits (@1Password)
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/plugins/modules/item_info.py
+++ b/plugins/modules/item_info.py
@@ -1,7 +1,20 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# (c) 2021, 1Password & Agilebits (@1Password)
+#  Copyright (C) 2021  1Password & Agilebits (@1Password)
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
 

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -48,7 +48,7 @@ function updateChangelog() {
 
     # Replace "Latest" in the top-most changelog block with new version
     # Then push a new "latest" block to top of the changelog
-    awk 'NR==1, /---/{ sub(/START\/LATEST/, "START/v'${VERSION_NUM}'"); sub(/# Latest/, "# v'${VERSION_NUM}'") } {print}' \
+    awk 'NR==1, /---/{ sub(/START\/LATEST/, "START/v'"${VERSION_NUM}"'"); sub(/# Latest/, "# v'"${VERSION_NUM}"'") } {print}' \
      "${changelogFile}" > "${tmpfile}"
 
     # Inserts "Latest" changelog HEREDOC at the top of the file

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -38,7 +38,7 @@ PATH_TO_PACKAGES="$(git rev-parse --show-toplevel)"
 DOCKER_IMG="default"
 
 # Minimum python version we support
-MIN_PYTHON_VERSION="3.8"
+MIN_PYTHON_VERSION="3.9"
 
 function _cleanup() {
   rm -r "${TMP_DIR_PATH}"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -38,7 +38,7 @@ PATH_TO_PACKAGES="$(git rev-parse --show-toplevel)"
 DOCKER_IMG="default"
 
 # Minimum python version we support
-MIN_PYTHON_VERSION="3.6"
+MIN_PYTHON_VERSION="3.8"
 
 function _cleanup() {
   rm -r "${TMP_DIR_PATH}"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -60,7 +60,7 @@ function inject_env_vars() {
   find ./tests/integration/ -type f -name "*.yml" -exec sed -i '' "s|__OP_CONNECT_HOST__|${OP_CONNECT_HOST}|g" {} +
   find ./tests/integration/ -type f -name "*.yml" -exec sed  -i '' "s|__OP_CONNECT_TOKEN__|${OP_CONNECT_TOKEN}|g" {} +
 
-  if [ ! -z "${OP_VAULT_ID+x}" ]; then
+  if [ -n "${OP_VAULT_ID+x}" ]; then
     find ./tests/integration -type f -name "*.yml" -exec sed -i '' "s|__OP_VAULT_ID__|${OP_VAULT_ID}|g" {} +
   fi
 

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -37,8 +37,8 @@ PATH_TO_PACKAGES="$(git rev-parse --show-toplevel)"
 # https://docs.ansible.com/ansible/latest/dev_guide/testing_integration.html#container-images
 DOCKER_IMG="default"
 
-# Minimum python version we support
-MIN_PYTHON_VERSION="3.9"
+# Minimum python version that is compatible with ansible versions in test matrix
+PYTHON_VERSION="3.9"
 
 function _cleanup() {
   rm -r "${TMP_DIR_PATH}"
@@ -87,7 +87,7 @@ function do_tests() {
   cd "${TMP_COLLECTIONS_PATH}/"
 
   echo "Initializing ansible-test ${TEST_SUITE} runner..........."
-  ANSIBLE_COLLECTIONS_PATH="${collection_path}" ansible-test "${TEST_SUITE}" --docker "${DOCKER_IMG}" --python "${MIN_PYTHON_VERSION}"
+  ANSIBLE_COLLECTIONS_PATH="${collection_path}" ansible-test "${TEST_SUITE}" --docker "${DOCKER_IMG}" --python "${PYTHON_VERSION}"
 }
 
 trap _cleanup EXIT

--- a/tests/unit/plugins/module_utils/test_item_assembly.py
+++ b/tests/unit/plugins/module_utils/test_item_assembly.py
@@ -116,7 +116,7 @@ def test_item_creation_minimum_values():
     assert not item["urls"]
     assert not item["tags"]
     assert not item["fields"]
-    assert "sections" not in "item"  # pylint: disable=comparison-of-constants
+    assert "sections" not in "item"  # pylint: disable=R0133
 
 
 def test_item_with_fields_in_sections():

--- a/tests/unit/plugins/module_utils/test_item_assembly.py
+++ b/tests/unit/plugins/module_utils/test_item_assembly.py
@@ -116,7 +116,7 @@ def test_item_creation_minimum_values():
     assert not item["urls"]
     assert not item["tags"]
     assert not item["fields"]
-    assert "sections" not in "item"  # pylint: disable=R0133
+    assert "sections" not in item
 
 
 def test_item_with_fields_in_sections():

--- a/tests/unit/plugins/module_utils/test_item_assembly.py
+++ b/tests/unit/plugins/module_utils/test_item_assembly.py
@@ -116,7 +116,7 @@ def test_item_creation_minimum_values():
     assert not item["urls"]
     assert not item["tags"]
     assert not item["fields"]
-    assert "sections" not in "item"  # pylint: disable=C0103
+    assert "sections" not in "item"  # pylint: disable=comparison-of-constants
 
 
 def test_item_with_fields_in_sections():

--- a/tests/unit/plugins/module_utils/test_item_assembly.py
+++ b/tests/unit/plugins/module_utils/test_item_assembly.py
@@ -116,7 +116,7 @@ def test_item_creation_minimum_values():
     assert not item["urls"]
     assert not item["tags"]
     assert not item["fields"]
-    assert "sections" not in "item"
+    assert "sections" not in "item"  # pylint: disable=C0103
 
 
 def test_item_with_fields_in_sections():

--- a/tests/unit/plugins/module_utils/test_item_crud.py
+++ b/tests/unit/plugins/module_utils/test_item_crud.py
@@ -2,8 +2,6 @@ from __future__ import (absolute_import, division, print_function)
 
 __metaclass__ = type
 
-import pytest
-
 from ansible_collections.onepassword.connect.plugins.module_utils import vault, const
 
 


### PR DESCRIPTION
This PR updates the piplines to use minimum ansible-core version `2.13` as older versions have EOL(end of life) status. See [support-matrix](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix).

Versions of `ansible-core` and `ansible` in USAGEGUIDE.md and CONTRIBUTE.md was changed according to the [ansible community changelog](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-community-changelogs). But collection is still working on the `ansible-core` versions `<2.13`.

Tested the collection locally using `ansible-core 2.13.x, 2.14.x, 2.15.x` by running simple playbook `ansible-playbook 1pass_playbook.yml` and verified that it works with Connect server.
