### PR TITLE
Prepare release v2.2.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,19 @@ onepassword.connect Release Notes
 .. contents:: Topics
 
 
+v2.2.2
+======
+
+Release Summary
+---------------
+
+This release contains small bugfixes and README changes. It also intends to go through new Ansible Automation Hub release process to keep the collection certified.
+
+Bugfixes
+--------
+
+- Improve error handling (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/64)
+
 v2.2.1
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -107,3 +107,13 @@ releases:
     - 58-bad-request-using-item-field-name.yaml
     - 64_handle_response_better.yaml
     release_date: '2022-08-30'
+  2.2.2:
+    changes:
+      bugfixes:
+      - Improve error handling (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/64)
+      release_summary: This release contains small bugfixes and README changes. It
+        also intends to go through new Ansible Automation Hub release process to keep
+        the collection certified.
+    fragments:
+    - release-2.2.2.yaml
+    release_date: '2023-09-20'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -4,7 +4,7 @@ namespace: onepassword
 name: connect
 
 # The version of the collection. Must be compatible with semantic versioning
-version: "2.2.1"
+version: "2.2.2"
 
 readme: README.md
 


### PR DESCRIPTION
```
  2.2.2:
    changes:
      bugfixes:
      - Improve error handling (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/64)
      release_summary: This release contains small bugfixes and README changes. It
        also intends to go through new Ansible Automation Hub release process to keep
        the collection certified.
    fragments:
    - release-2.2.2.yaml
    release_date: '2023-09-20'
```