### PR TITLE
Bump ansible-core v2.14

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,2 +1,3 @@
 exclude_paths:
     - .github/
+    - tests/integration/targets/generic_item/vars/main.yml

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,2 @@
+exclude_paths:
+    - .github/

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -1,0 +1,14 @@
+---
+name: ansible-lint
+on:
+  pull_request:
+    branches:
+      - "main"
+jobs:
+  build:
+    name: Ansible Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run ansible-lint
+        uses: ansible/ansible-lint@main

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -11,4 +11,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run ansible-lint
-        uses: ansible/ansible-lint@main
+        uses: ansible/ansible-lint@v6.21.1

--- a/.github/workflows/ansible-tests.yml
+++ b/.github/workflows/ansible-tests.yml
@@ -28,6 +28,10 @@ jobs:
             python: "3.8"
           - ansible: "2.15"
             python: "3.8"
+          - ansible: "2.16"
+            python: "3.8"
+          - ansible: "2.16"
+            python: "3.9"
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/ansible-tests.yml
+++ b/.github/workflows/ansible-tests.yml
@@ -7,7 +7,7 @@ on:
       - "main"
 
 env:
-  PYTHON_VERSION: "3.9"
+  PYTHON_VERSION: "3.10"
   # arbitrarily choosing the latest stable version to run ansible-test units
   # running 'ansible-test units' for each ansible+python version isn't necessary
   ANSIBLE_FOR_UNIT_TESTS: "2.15"

--- a/.github/workflows/ansible-tests.yml
+++ b/.github/workflows/ansible-tests.yml
@@ -79,8 +79,15 @@ jobs:
       - name: Install ansible-core stable-${{ env.ANSIBLE_FOR_UNIT_TESTS }}
         run: pip install https://github.com/ansible/ansible/archive/stable-${{ env.ANSIBLE_FOR_UNIT_TESTS }}.tar.gz --disable-pip-version-check
 
-      - name: ansible-lint version
-        run: ansible-lint --version
-
       - name: Run ansible-test units
         run: ansible-test units -v --docker --redact --python ${{ env.PYTHON_VERSION }}
+
+  ansible-lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ env.COLLECTION_PATH }}
+    steps:
+      - name: run-ansible-lint
+        uses: ansible/ansible-lint@v6.22.0

--- a/.github/workflows/ansible-tests.yml
+++ b/.github/workflows/ansible-tests.yml
@@ -79,5 +79,8 @@ jobs:
       - name: Install ansible-core stable-${{ env.ANSIBLE_FOR_UNIT_TESTS }}
         run: pip install https://github.com/ansible/ansible/archive/stable-${{ env.ANSIBLE_FOR_UNIT_TESTS }}.tar.gz --disable-pip-version-check
 
+      - name: ansible-test version
+        run: ansible-test --version
+
       - name: Run ansible-test units
         run: ansible-test units -v --docker --redact --python ${{ env.PYTHON_VERSION }}

--- a/.github/workflows/ansible-tests.yml
+++ b/.github/workflows/ansible-tests.yml
@@ -79,8 +79,8 @@ jobs:
       - name: Install ansible-core stable-${{ env.ANSIBLE_FOR_UNIT_TESTS }}
         run: pip install https://github.com/ansible/ansible/archive/stable-${{ env.ANSIBLE_FOR_UNIT_TESTS }}.tar.gz --disable-pip-version-check
 
-      - name: ansible-test version
-        run: ansible-test --version
+      - name: ansible-lint version
+        run: ansible-lint --version
 
       - name: Run ansible-test units
         run: ansible-test units -v --docker --redact --python ${{ env.PYTHON_VERSION }}

--- a/.github/workflows/ansible-tests.yml
+++ b/.github/workflows/ansible-tests.yml
@@ -21,11 +21,9 @@ jobs:
     strategy:
       # https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
       matrix:
-        ansible: ["2.13", "2.14", "2.15"]
+        ansible: ["2.14", "2.15", "2.16"]
         python: ["3.8", "3.9", "3.10", "3.11"]
         exclude:
-          - ansible: "2.13"
-            python: "3.11"
           - ansible: "2.14"
             python: "3.8"
           - ansible: "2.15"

--- a/.github/workflows/ansible-tests.yml
+++ b/.github/workflows/ansible-tests.yml
@@ -81,13 +81,3 @@ jobs:
 
       - name: Run ansible-test units
         run: ansible-test units -v --docker --redact --python ${{ env.PYTHON_VERSION }}
-
-  ansible-lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ${{ env.COLLECTION_PATH }}
-    steps:
-      - name: run-ansible-lint
-        uses: ansible/ansible-lint@v6.22.0

--- a/.github/workflows/ansible-tests.yml
+++ b/.github/workflows/ansible-tests.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-            python-version: ${{env.PYTHON_VERSION}}
+            python-version: ${{ matrix.python }}
 
       - name: Install ansible-core stable-${{ matrix.ansible }}
         run: |

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -18,8 +18,8 @@ This collection requires **Python v3.8 or greater**. If you don't have Python in
 
 
 Current Ansible-core and Ansible version supported:
-- `ansible-core`: **>=2.13**
-- `ansible`: **>=6.x**
+- `ansible-core`: **>=2.14**
+- `ansible`: **>=7.x**
 
 We recommend installing Ansible in a `virtualenv` created specifically for this project. 
 
@@ -29,7 +29,7 @@ We recommend installing Ansible in a `virtualenv` created specifically for this 
 python3 -m venv <path_to_venv>/onepassword_ansible
 source <path_to_venv>/onepassword_ansible activate
 
-pip3 install 'ansible-core==2.11.*' 'ansible>=4.0,<5'
+pip3 install 'ansible-core==2.14.*' 'ansible>=7.x'
 ```
 
 ### Clone the Repo

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,12 @@ SCRIPTS_DIR := $(CURDIR)/scripts
 
 curVersion := $$(sed -n -E 's/^version: "([0-9]+\.[0-9]+\.[0-9]+)"$$/\1/p' galaxy.yml)
 
+lint:
+	@ansible-lint --offline
+
+lint/fix:
+	@ansible-lint --offline --fix
+
 test/unit:	## Run unit tests in a Docker container
 	$(SCRIPTS_DIR)/run-tests.sh units
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
 The 1Password Connect collection contains modules that interact with your 1Password Connect deployment. The modules communicate with the 1Password Connect API to support Vault Item create/read/update/delete operations.
 
 ## Requirements
-- `ansible`: **>=6.x**
-- `ansible-core`: **>=2.13**
+- `ansible`: **>=7.x**
+- `ansible-core`: **>=2.14**
 - `python`: **>=3.8**
 - `1Password Connect`: **>= 1.0.0**
 

--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -11,22 +11,14 @@ prelude_section_name: release_summary
 prelude_section_title: Release Summary
 sanitize_changelog: true
 sections:
-- - major_changes
-  - Major Changes
-- - minor_changes
-  - Minor Changes
-- - breaking_changes
-  - Breaking Changes / Porting Guide
-- - deprecated_features
-  - Deprecated Features
-- - removed_features
-  - Removed Features (previously deprecated)
-- - security_fixes
-  - Security Fixes
-- - bugfixes
-  - Bugfixes
-- - known_issues
-  - Known Issues
+ - ['major_changes', 'Major Changes']
+ - ['minor_changes', 'Minor Changes']
+ - ['breaking_changes', 'Breaking Changes / Porting Guide']
+ - ['deprecated_features', 'Deprecated Features']
+ - ['removed_features', 'Removed Features (previously deprecated)']
+ - ['security_fixes', 'Security Fixes']
+ - ['bugfixes', 'Bugfixes']
+ - ['known_issues', 'Known Issues']
 title: onepassword.connect
 trivial_section_name: trivial
 use_fqcn: true

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,10 +1,11 @@
+---
 namespace: onepassword
 
 # The name of the collection.
 name: connect
 
 # The version of the collection. Must be compatible with semantic versioning
-version: "2.2.3"
+version: 2.2.3
 
 readme: README.md
 
@@ -13,12 +14,10 @@ authors:
 
 description: Modules for managing and reading 1Password Vaults with 1Password Connect.
 
-license_file: 'LICENSE.md'
+license_file: LICENSE.md
 
-tags: ['security', 'onepassword', 'secrets', 'onepasswordconnect', 'connect']
-
+tags: [security, onepassword, secrets, onepasswordconnect, connect]
 dependencies: {}
-
 repository: https://github.com/1Password/ansible-onepasswordconnect-collection
 
 # The URL to any online docs
@@ -32,4 +31,4 @@ issues: https://github.com/1Password/ansible-onepasswordconnect-collection/issue
 
 # A list of file glob-like patterns used to filter any files or directories that should not be included in the build
 # artifact.
-build_ignore: ['scripts', '.venv', 'venv', '.*', 'tests']
+build_ignore: [scripts, .venv, venv, .*, tests]

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.13.0'
+requires_ansible: '>=2.14.0'

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.14.0'
+requires_ansible: ">=2.14.0"

--- a/plugins/modules/generic_item.py
+++ b/plugins/modules/generic_item.py
@@ -197,10 +197,10 @@ EXAMPLES = '''
         field_type: concealed
         generate_value: on_create
         generator_recipe:
-            length: 16
-            include_letters: yes
-            include_digits: yes
-            include_symbols: no
+          length: 16
+          include_letters: true
+          include_digits: true
+          include_symbols: false
         section: Club Card Details
   register: op_item  # Access item values through `op_item['data']`
   no_log: true       # Hide the output - it will contain the secret value you just stored
@@ -212,13 +212,13 @@ EXAMPLES = '''
     fields:
       - label: Secret Code
         field_type: concealed
-        overwrite: no
+        overwrite: false
         generate_value: never
         generator_recipe: # ignored because generate_value == never
-            length: 16
-            include_letters: yes
-            include_digits: yes
-            include_symbols: no
+          length: 16
+          include_letters: true
+          include_digits: true
+          include_symbols: false
         section: Club Card Details
   no_log: true
 
@@ -230,13 +230,13 @@ EXAMPLES = '''
     fields:
       - label: Secret Code
         field_type: concealed
-        overwrite: no
+        overwrite: false
         generate_value: on_create
         generator_recipe: # ignored because generate_value == never
-            length: 16
-            include_letters: yes
-            include_digits: yes
-            include_symbols: no
+          length: 16
+          include_letters: true
+          include_digits: true
+          include_symbols: false
         section: Club Card Details
   no_log: true
 

--- a/tests/integration/targets/field_info/tasks/main.yml
+++ b/tests/integration/targets/field_info/tasks/main.yml
@@ -6,6 +6,6 @@
 - name: Field Info task
   ansible.builtin.import_tasks: tests.yml
   environment:
-    OP_CONNECT_HOST: "__OP_CONNECT_HOST__"
-    OP_CONNECT_TOKEN: "__OP_CONNECT_TOKEN__"
-    OP_VAULT_ID: "__OP_VAULT_ID__"
+    OP_CONNECT_HOST: __OP_CONNECT_HOST__
+    OP_CONNECT_TOKEN: __OP_CONNECT_TOKEN__
+    OP_VAULT_ID: __OP_VAULT_ID__

--- a/tests/integration/targets/field_info/tasks/main.yml
+++ b/tests/integration/targets/field_info/tasks/main.yml
@@ -3,7 +3,8 @@
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 ---
-- import_tasks: tests.yml
+- name: Field Info task
+  ansible.builtin.import_tasks: tests.yml
   environment:
     OP_CONNECT_HOST: "__OP_CONNECT_HOST__"
     OP_CONNECT_TOKEN: "__OP_CONNECT_TOKEN__"

--- a/tests/integration/targets/field_info/tasks/tests.yml
+++ b/tests/integration/targets/field_info/tasks/tests.yml
@@ -1,9 +1,8 @@
 ---
-
 - name: Set Fact
   ansible.builtin.set_fact:
-    field_label_to_find: "frogs frogs frogs"
-    item_title: "Test Field Lookup - ANSIBLE {{ 9999 | random }}"
+    field_label_to_find: frogs frogs frogs
+    item_title: Test Field Lookup - ANSIBLE {{ 9999 | random }}
     created_item_ids: []
 
 - name: Setup | Create a test item
@@ -42,8 +41,8 @@
 - name: Find Field | Assert root field was found
   ansible.builtin.assert:
     that:
-      - "found_root_field.field.value == test_item.op_item.fields['{{ field_label_to_find }}'].value"
-      - "found_root_field.field.id == test_item.op_item.fields['{{ field_label_to_find }}'].id"
+      - found_root_field.field.value == test_item.op_item.fields['{{ field_label_to_find }}'].value
+      - found_root_field.field.id == test_item.op_item.fields['{{ field_label_to_find }}'].id
 
 - name: Find Field | Search by item ID
   field_info:
@@ -54,13 +53,12 @@
 
 - name: Find Field | Assert field was found
   ansible.builtin.assert:
-    that:
-      "found_field_by_item_id.field.id == test_item.op_item.fields['{{ field_label_to_find }}'].id"
+    that: found_field_by_item_id.field.id == test_item.op_item.fields['{{ field_label_to_find }}'].id
 
 - name: Find Field | Search by unknown item label
   field_info:
     item: "{{ test_item.op_item.id }}"
-    field: "doesNotExist"
+    field: doesNotExist
     vault: "{{ test_item.op_item.vault.id }}"
   register: notfound_result
   ignore_errors: true
@@ -88,7 +86,7 @@
 - name: Find Field | Search with section label for undefined field
   field_info:
     item: "{{ item_title }}"
-    field: "doesNotExist"
+    field: doesNotExist
     vault: "{{ test_item.op_item.vault.id }}"
   register: notfound_bysection_result
   ignore_errors: true

--- a/tests/integration/targets/field_info/tasks/tests.yml
+++ b/tests/integration/targets/field_info/tasks/tests.yml
@@ -1,6 +1,7 @@
 ---
 
-- set_fact:
+- name: Set Fact
+  ansible.builtin.set_fact:
     field_label_to_find: "frogs frogs frogs"
     item_title: "Test Field Lookup - ANSIBLE {{ 9999 | random }}"
     created_item_ids: []
@@ -27,18 +28,19 @@
 
   register: test_item
 
-- set_fact:
+- name: Set Fact
+  ansible.builtin.set_fact:
     mysql_section_id: test_item.op_item.sections[0].id
 
 - name: Find Field | Field in item root
   field_info:
     item: "{{ item_title }}"
     field: "{{ field_label_to_find }}"
-    vault: "{{test_item.op_item.vault.id}}"
+    vault: "{{ test_item.op_item.vault.id }}"
   register: found_root_field
 
 - name: Find Field | Assert root field was found
-  assert:
+  ansible.builtin.assert:
     that:
       - "found_root_field.field.value == test_item.op_item.fields['{{ field_label_to_find }}'].value"
       - "found_root_field.field.id == test_item.op_item.fields['{{ field_label_to_find }}'].id"
@@ -47,28 +49,27 @@
   field_info:
     item: "{{ test_item.op_item.id }}"
     field: "{{ field_label_to_find }}"
-    vault: "{{test_item.op_item.vault.id}}"
+    vault: "{{ test_item.op_item.vault.id }}"
   register: found_field_by_item_id
 
 - name: Find Field | Assert field was found
-  assert:
+  ansible.builtin.assert:
     that:
       "found_field_by_item_id.field.id == test_item.op_item.fields['{{ field_label_to_find }}'].id"
 
-- block:
-  - name: Find Field | Search by unknown item label
-    field_info:
-      item: "{{ test_item.op_item.id }}"
-      field: "doesNotExist"
-      vault: "{{test_item.op_item.vault.id}}"
-    register: notfound_result
-  ignore_errors: yes
+- name: Find Field | Search by unknown item label
+  field_info:
+    item: "{{ test_item.op_item.id }}"
+    field: "doesNotExist"
+    vault: "{{ test_item.op_item.vault.id }}"
+  register: notfound_result
+  ignore_errors: true
 
 - name: Find Field | Assert field not found returns error
-  assert:
+  ansible.builtin.assert:
     that:
       - notfound_result.failed
-      - "{{ notfound_result.field|length }} == 0"
+      - "{{ notfound_result.field | length }} == 0"
 
 - name: Find Field | Search with section label
   field_info:
@@ -79,25 +80,24 @@
   register: mysql_field
 
 - name: Find Field by Section | Assert field within MySQL section was found
-  assert:
+  ansible.builtin.assert:
     that:
       - mysql_field.field.value == "penny"
       - mysql_field.field.section
 
-- block:
-  - name: Find Field | Search with section label for undefined field
-    field_info:
-      item: "{{ item_title }}"
-      field: "doesNotExist"
-      vault: "{{test_item.op_item.vault.id}}"
-    register: notfound_bysection_result
-  ignore_errors: yes
+- name: Find Field | Search with section label for undefined field
+  field_info:
+    item: "{{ item_title }}"
+    field: "doesNotExist"
+    vault: "{{ test_item.op_item.vault.id }}"
+  register: notfound_bysection_result
+  ignore_errors: true
 
 - name: Find Field | Assert field not found returns error
-  assert:
+  ansible.builtin.assert:
     that:
       - notfound_bysection_result.failed
-      - "{{ notfound_bysection_result.field|length }} == 0"
+      - "{{ notfound_bysection_result.field | length }} == 0"
 
 - name: Cleanup | Remove test items
   generic_item:

--- a/tests/integration/targets/generic_item/tasks/main.yml
+++ b/tests/integration/targets/generic_item/tasks/main.yml
@@ -3,7 +3,8 @@
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 ---
-- import_tasks: tests.yml
+- name: Generic Item task
+  ansible.builtin.import_tasks: tests.yml
   environment:
     OP_CONNECT_HOST: "__OP_CONNECT_HOST__"
     OP_CONNECT_TOKEN: "__OP_CONNECT_TOKEN__"

--- a/tests/integration/targets/generic_item/tasks/main.yml
+++ b/tests/integration/targets/generic_item/tasks/main.yml
@@ -6,6 +6,6 @@
 - name: Generic Item task
   ansible.builtin.import_tasks: tests.yml
   environment:
-    OP_CONNECT_HOST: "__OP_CONNECT_HOST__"
-    OP_CONNECT_TOKEN: "__OP_CONNECT_TOKEN__"
-    OP_VAULT_ID: "__OP_VAULT_ID__"
+    OP_CONNECT_HOST: __OP_CONNECT_HOST__
+    OP_CONNECT_TOKEN: __OP_CONNECT_TOKEN__
+    OP_VAULT_ID: __OP_VAULT_ID__

--- a/tests/integration/targets/generic_item/tasks/tests.yml
+++ b/tests/integration/targets/generic_item/tasks/tests.yml
@@ -1,6 +1,7 @@
 ---
 
-- set_fact:
+- name: Set Facts
+  ansible.builtin.set_fact:
     field_wont_exist_after_update: "transitoryExampleLabel"
     original_item_title: "Example Item - ANSIBLE TEST {{ 9999 | random }}"
     created_item_ids: []
@@ -18,7 +19,7 @@
         field_type: concealed
         generate_value: always
         generator_recipe:
-          include_digits: no
+          include_digits: false
 
       - label: "{{ field_wont_exist_after_update }}"
         value: example
@@ -34,7 +35,7 @@
 # NOTE: Connect server <= 1.2.0 changes name of the field with purpose==PASSWORD
 #   to `password`
 - name: Create Item | Assert expected item properties and fields
-  assert:
+  ansible.builtin.assert:
     that:
       - original.changed
       - original.op_item is defined
@@ -43,8 +44,9 @@
       - original.op_item.fields.password is defined
       - "original.op_item.fields.password.purpose == 'PASSWORD'"
 
-- set_fact:
-    created_item_ids: "{{ created_item_ids + [ original.op_item.id ] }}"
+- name: Set facts
+  ansible.builtin.set_fact:
+    created_item_ids: "{{ created_item_ids + [original.op_item.id] }}"
     updated_item_title: "{{ original.op_item.title }} UPDATED"
 
 - name: Upsert item
@@ -61,7 +63,7 @@
         field_type: concealed
         generate_value: on_create
         generator_recipe:
-          include_digits: no
+          include_digits: false
 
       - label: Generated String
         generate_value: always
@@ -69,7 +71,7 @@
   register: updated_1p_item
 
 - name: Upsert item | Assert updated item properties
-  assert:
+  ansible.builtin.assert:
     that:
       - updated_1p_item.changed
       - updated_1p_item.op_item.id == original.op_item.id
@@ -79,7 +81,7 @@
       - "updated_1p_item.op_item.fields['Generated String'].value != original.op_item.fields['Generated String'].value"
 
 - name: Upsert item | Assert tags updated
-  assert:
+  ansible.builtin.assert:
     that:
       - "'{{ item }}' in updated_1p_item.op_item.tags"
   with_items:
@@ -99,7 +101,7 @@
         field_type: concealed
         generate_value: on_create
         generator_recipe:
-          include_digits: no
+          include_digits: false
 
       - label: Hello
         value: "World"
@@ -110,7 +112,7 @@
   register: updated_1p_item_by_name
 
 - name: Update Item by Name | Assert existing fields are preserved
-  assert:
+  ansible.builtin.assert:
     that:
       - "'{{ item }}' in updated_1p_item_by_name.op_item.fields"
       - "updated_1p_item_by_name.op_item.fields['{{ item }}'].value == updated_1p_item.op_item.fields['{{ item }}'].value"
@@ -128,13 +130,14 @@
   register: item_with_default_template
 
 - name: Default Template | Default template was used
-  assert:
+  ansible.builtin.assert:
     that:
       - item_with_default_template.changed
       - 'item_with_default_template.op_item.category == "API_CREDENTIAL"'
 
-- set_fact:
-    created_item_ids: "{{ created_item_ids + [ item_with_default_template.op_item.id ] }}"
+- name: Set Facts
+  ansible.builtin.set_fact:
+    created_item_ids: "{{ created_item_ids + [item_with_default_template.op_item.id] }}"
 
 - name: Cleanup | Remove created items
   generic_item:

--- a/tests/integration/targets/generic_item/tasks/tests.yml
+++ b/tests/integration/targets/generic_item/tasks/tests.yml
@@ -1,11 +1,10 @@
 ---
-
 - name: Set Facts
   ansible.builtin.set_fact:
-    field_wont_exist_after_update: "transitoryExampleLabel"
-    original_item_title: "Example Item - ANSIBLE TEST {{ 9999 | random }}"
+    field_wont_exist_after_update: transitoryExampleLabel
+    original_item_title: Example Item - ANSIBLE TEST {{ 9999 | random }}
     created_item_ids: []
-    default_tempalte: "API_CREDENTIAL"
+    default_tempalte: API_CREDENTIAL
 
 - name: Create Item
   generic_item:
@@ -42,7 +41,7 @@
       - original.op_item.id is defined
       - original.op_item.fields.mypassword is not defined
       - original.op_item.fields.password is defined
-      - "original.op_item.fields.password.purpose == 'PASSWORD'"
+      - original.op_item.fields.password.purpose == 'PASSWORD'
 
 - name: Set facts
   ansible.builtin.set_fact:
@@ -67,7 +66,7 @@
 
       - label: Generated String
         generate_value: always
-        section: "Collaboration Details"
+        section: Collaboration Details
   register: updated_1p_item
 
 - name: Upsert item | Assert updated item properties
@@ -78,7 +77,7 @@
       - updated_1p_item.op_item.title == updated_item_title
       - updated_1p_item.op_item.fields.password.value == original.op_item.fields.password.value
       - field_wont_exist_after_update not in updated_1p_item.op_item.fields
-      - "updated_1p_item.op_item.fields['Generated String'].value != original.op_item.fields['Generated String'].value"
+      - updated_1p_item.op_item.fields['Generated String'].value != original.op_item.fields['Generated String'].value
 
 - name: Upsert item | Assert tags updated
   ansible.builtin.assert:
@@ -104,18 +103,18 @@
           include_digits: false
 
       - label: Hello
-        value: "World"
+        value: World
 
       - label: Generated String
         generate_value: always
-        section: "Collaboration Details"
+        section: Collaboration Details
   register: updated_1p_item_by_name
 
 - name: Update Item by Name | Assert existing fields are preserved
   ansible.builtin.assert:
     that:
       - "'{{ item }}' in updated_1p_item_by_name.op_item.fields"
-      - "updated_1p_item_by_name.op_item.fields['{{ item }}'].value == updated_1p_item.op_item.fields['{{ item }}'].value"
+      - updated_1p_item_by_name.op_item.fields['{{ item }}'].value == updated_1p_item.op_item.fields['{{ item }}'].value
   with_items:
     - password
 
@@ -126,14 +125,14 @@
     fields:
       - label: Generated String
         generate_value: always
-        section: "Collaboration Details"
+        section: Collaboration Details
   register: item_with_default_template
 
 - name: Default Template | Default template was used
   ansible.builtin.assert:
     that:
       - item_with_default_template.changed
-      - 'item_with_default_template.op_item.category == "API_CREDENTIAL"'
+      - item_with_default_template.op_item.category == "API_CREDENTIAL"
 
 - name: Set Facts
   ansible.builtin.set_fact:

--- a/tests/integration/targets/generic_item/vars/main.yml
+++ b/tests/integration/targets/generic_item/vars/main.yml
@@ -1,3 +1,7 @@
 # This is a "fake" JWT; its decoded form does not adhere to the Server spec nor does it contain any valid data.
-op_api_token: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MDMzMDUyMTgsImV4cCI6MTYzNDg0MTIxOCwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJFbWFpbCI6Impyb2NrZXRAZXhhbXBsZS5jb20iLCJSb2xlIjpbIk1hbmFnZXIiLCJQcm9qZWN0IEFkbWluaXN0cmF0b3IiXX0.vJ7uaGuJ3Gn1gTgwjs96pUp4YiOjoH9zaSO0dT77uAY"
+op_api_token: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.\
+               eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MDMzMDUyMTgsImV4cCI6MTYzNDg0MTIxOCwiYXVkIjoid3d3LmV4\
+               YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2Nr\
+               ZXQiLCJFbWFpbCI6Impyb2NrZXRAZXhhbXBsZS5jb20iLCJSb2xlIjpbIk1hbmFnZXIiLCJQcm9qZWN0IEFkbWluaXN0cmF0b3IiXX0.\
+               vJ7uaGuJ3Gn1gTgwjs96pUp4YiOjoH9zaSO0dT77uAY"
 op_server_url: http://localhost:8080"

--- a/tests/integration/targets/generic_item/vars/main.yml
+++ b/tests/integration/targets/generic_item/vars/main.yml
@@ -1,7 +1,3 @@
 # This is a "fake" JWT; its decoded form does not adhere to the Server spec nor does it contain any valid data.
-op_api_token: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.\
-               eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MDMzMDUyMTgsImV4cCI6MTYzNDg0MTIxOCwiYXVkIjoid3d3LmV4\
-               YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2Nr\
-               ZXQiLCJFbWFpbCI6Impyb2NrZXRAZXhhbXBsZS5jb20iLCJSb2xlIjpbIk1hbmFnZXIiLCJQcm9qZWN0IEFkbWluaXN0cmF0b3IiXX0.\
-               vJ7uaGuJ3Gn1gTgwjs96pUp4YiOjoH9zaSO0dT77uAY"
+op_api_token: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MDMzMDUyMTgsImV4cCI6MTYzNDg0MTIxOCwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJFbWFpbCI6Impyb2NrZXRAZXhhbXBsZS5jb20iLCJSb2xlIjpbIk1hbmFnZXIiLCJQcm9qZWN0IEFkbWluaXN0cmF0b3IiXX0.vJ7uaGuJ3Gn1gTgwjs96pUp4YiOjoH9zaSO0dT77uAY"
 op_server_url: http://localhost:8080"

--- a/tests/integration/targets/item_info/tasks/main.yml
+++ b/tests/integration/targets/item_info/tasks/main.yml
@@ -6,6 +6,6 @@
 - name: Item Info task
   ansible.builtin.import_tasks: tests.yml
   environment:
-    OP_CONNECT_HOST: "__OP_CONNECT_HOST__"
-    OP_CONNECT_TOKEN: "__OP_CONNECT_TOKEN__"
-    OP_VAULT_ID: "__OP_VAULT_ID__"
+    OP_CONNECT_HOST: __OP_CONNECT_HOST__
+    OP_CONNECT_TOKEN: __OP_CONNECT_TOKEN__
+    OP_VAULT_ID: __OP_VAULT_ID__

--- a/tests/integration/targets/item_info/tasks/main.yml
+++ b/tests/integration/targets/item_info/tasks/main.yml
@@ -3,7 +3,8 @@
 # and should not be used as examples of how to write Ansible roles #
 ####################################################################
 ---
-- import_tasks: tests.yml
+- name: Item Info task
+  ansible.builtin.import_tasks: tests.yml
   environment:
     OP_CONNECT_HOST: "__OP_CONNECT_HOST__"
     OP_CONNECT_TOKEN: "__OP_CONNECT_TOKEN__"

--- a/tests/integration/targets/item_info/tasks/tests.yml
+++ b/tests/integration/targets/item_info/tasks/tests.yml
@@ -1,9 +1,8 @@
 ---
-
 - name: Create a test item
   generic_item:
     state: present
-    title: "Test Item - ANSIBLETEST {{ 9999 | random }}"
+    title: Test Item - ANSIBLETEST {{ 9999 | random }}
     category: server
     tags:
       - exampleTag
@@ -15,7 +14,7 @@
 - name: Create a second test item
   generic_item:
     state: present
-    title: "Test Item 2 - ANSIBLETEST {{ 9999 | random }}"
+    title: Test Item 2 - ANSIBLETEST {{ 9999 | random }}
     category: server
     tags:
       - exampleTag
@@ -106,7 +105,6 @@
   generic_item:
     state: absent
     uuid: "{{ test_item.op_item.id }}"
-
 
 - name: Delete test item
   generic_item:

--- a/tests/integration/targets/item_info/tasks/tests.yml
+++ b/tests/integration/targets/item_info/tasks/tests.yml
@@ -26,15 +26,15 @@
 
 - name: Get two items at once
   item_info:
-      item: "{{ item }}"
-      vault: "{{test_item.op_item.vault.id}}"
+    item: "{{ item }}"
+    vault: "{{ test_item.op_item.vault.id }}"
   register: found
   with_items:
-    - "{{test_item.op_item.id}}"
-    - "{{test_item2.op_item.id}}"
+    - "{{ test_item.op_item.id }}"
+    - "{{ test_item2.op_item.id }}"
 
 - name: Assert the two items have correct properties
-  assert:
+  ansible.builtin.assert:
     that:
       - found.results[0].op_item is defined
       - found.results[0].op_item.title == test_item.op_item.title
@@ -43,72 +43,72 @@
 
 - name: Get item with Vault ID and Item ID
   item_info:
-    item: "{{test_item.op_item.id}}"
-    vault: "{{test_item.op_item.vault.id}}"
+    item: "{{ test_item.op_item.id }}"
+    vault: "{{ test_item.op_item.vault.id }}"
   register: result
 
 - name: Assert correct item properties
-  assert:
+  ansible.builtin.assert:
     that:
       - result.op_item is defined
       - result.op_item.title == test_item.op_item.title
 
 - name: Get item field with Vault ID and Item ID
   item_info:
-    item: "{{test_item.op_item.id}}"
-    vault: "{{test_item.op_item.vault.id}}"
+    item: "{{ test_item.op_item.id }}"
+    vault: "{{ test_item.op_item.vault.id }}"
     field: Test
   register: result
 
 - name: Assert correct item properties
-  assert:
+  ansible.builtin.assert:
     that:
       - result.field is defined
       - result.field == 'Hello'
 
 - name: Get item with Item ID and without providing Vault
   item_info:
-    item: "{{test_item.op_item.id}}"
+    item: "{{ test_item.op_item.id }}"
   register: result
 
 - name: Assert correct item properties
-  assert:
+  ansible.builtin.assert:
     that:
       - result.op_item is defined
       - result.op_item.title == test_item.op_item.title
 
 - name: Get item field with Vault ID and Item Name
   item_info:
-    item: "{{test_item.op_item.title}}"
-    vault: "{{test_item.op_item.vault.id}}"
+    item: "{{ test_item.op_item.title }}"
+    vault: "{{ test_item.op_item.vault.id }}"
   register: result
 
 - name: Assert correct item properties
-  assert:
+  ansible.builtin.assert:
     that:
       - result.op_item is defined
       - result.op_item.title == test_item.op_item.title
 
-#If you wish to run this test, remove the comments and add the correct vault name
-#- name: Get item with Vault name and Item name
-#  item_info:
-#    item: "{{test_item.op_item.title}}"
-#    vault: <Insert Vault Name>
-#  register: result
+# If you wish to run this test, remove the comments and add the correct vault name
+# - name: Get item with Vault name and Item name
+#   item_info:
+#     item: "{{test_item.op_item.title}}"
+#     vault: <Insert Vault Name>
+#   register: result
 
-#- name: Assert correct item properties
-#  assert:
-#    that:
-#      - result.op_item is defined
-#      - result.op_item.title == test_item.op_item.title
-
-- name: Delete test item
-  generic_item:
-    state: absent
-    uuid: "{{test_item.op_item.id}}"
-
+# - name: Assert correct item properties
+#   ansible.builtin.assert:
+#     that:
+#       - result.op_item is defined
+#       - result.op_item.title == test_item.op_item.title
 
 - name: Delete test item
   generic_item:
     state: absent
-    uuid: "{{test_item2.op_item.id}}"
+    uuid: "{{ test_item.op_item.id }}"
+
+
+- name: Delete test item
+  generic_item:
+    state: absent
+    uuid: "{{ test_item2.op_item.id }}"


### PR DESCRIPTION
This PR makes the changes required to make as `ansible-core v2.13` is end of life.

Changes are done:
- `ansible-core v2.14` is used in the following files `CHANGELOG.md`, `README.md`, `meta/runtime.yml`
- `ansible-lint` GitHub Actions workflow is added to lint the collection.
-  `.github/workflows/ansible-tests.yml` exclude `v2.13` and include `v2.16`. Also slightly update the test matrix to run each sanity check on the compatible python version from `python` matrix array.
- The rest of the files are changed due to fixing `lint` errors and warnings.


The new version will be released after this PR is merged.