### PR TITLE
Remove Ansible core 2.14 and set 2.15 as minimum required version

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,3 +1,4 @@
+---
 exclude_paths:
-    - .github/
-    - tests/integration/targets/generic_item/vars/main.yml
+  - .github/
+  - tests/integration/targets/generic_item/vars/main.yml

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -11,4 +11,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run ansible-lint
-        uses: ansible/ansible-lint@v6.21.1
+        uses: ansible/ansible-lint@v6.22.2

--- a/.github/workflows/ansible-tests.yml
+++ b/.github/workflows/ansible-tests.yml
@@ -21,15 +21,9 @@ jobs:
     strategy:
       # https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
       matrix:
-        ansible: ["2.14", "2.15", "2.16"]
-        python: ["3.8", "3.9", "3.10", "3.11"]
+        ansible: ["2.15", "2.16"]
+        python: ["3.9", "3.10", "3.11"]
         exclude:
-          - ansible: "2.14"
-            python: "3.8"
-          - ansible: "2.15"
-            python: "3.8"
-          - ansible: "2.16"
-            python: "3.8"
           - ansible: "2.16"
             python: "3.9"
     runs-on: ubuntu-latest
@@ -40,12 +34,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-            path: ${{ env.COLLECTION_PATH }}
+          path: ${{ env.COLLECTION_PATH }}
 
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-            python-version: ${{ matrix.python }}
+          python-version: ${{ matrix.python }}
 
       - name: Install ansible-core stable-${{ matrix.ansible }}
         run: |

--- a/.github/workflows/ansible-tests.yml
+++ b/.github/workflows/ansible-tests.yml
@@ -22,10 +22,12 @@ jobs:
       # https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
       matrix:
         ansible: ["2.15", "2.16"]
-        python: ["3.9", "3.10", "3.11"]
+        python: ["3.9", "3.10", "3.11", "3.12"]
         exclude:
           - ansible: "2.16"
             python: "3.9"
+          - ansible: "2.15"
+            python: "3.12"
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -18,7 +18,7 @@ This collection requires **Python v3.8 or greater**. If you don't have Python in
 
 
 Current Ansible-core and Ansible version supported:
-- `ansible-core`: **>=2.14**
+- `ansible-core`: **>=2.15**
 - `ansible`: **>=7.x**
 
 We recommend installing Ansible in a `virtualenv` created specifically for this project. 
@@ -29,7 +29,7 @@ We recommend installing Ansible in a `virtualenv` created specifically for this 
 python3 -m venv <path_to_venv>/onepassword_ansible
 source <path_to_venv>/onepassword_ansible activate
 
-pip3 install 'ansible-core==2.14.*' 'ansible>=7.x'
+pip3 install 'ansible-core==2.15.*' 'ansible>=7.x'
 ```
 
 ### Clone the Repo

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -14,7 +14,7 @@ After reading this document, you will:
 
 > If you have already installed a supported version of Ansible, you can skip to the [Clone the Repo](#clone-the-repo) step.
 
-This collection requires **Python v3.8 or greater**. If you don't have Python installed, consider using [pyenv](https://github.com/pyenv/pyenv) to install the supported Python runtime.
+This collection requires **Python v3.9 or greater**. If you don't have Python installed, consider using [pyenv](https://github.com/pyenv/pyenv) to install the supported Python runtime.
 
 
 Current Ansible-core and Ansible version supported:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The 1Password Connect collection contains modules that interact with your 1Passw
 
 ## Requirements
 - `ansible`: **>=7.x**
-- `ansible-core`: **>=2.14**
+- `ansible-core`: **>=2.15**
 - `python`: **>=3.8**
 - `1Password Connect`: **>= 1.0.0**
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The 1Password Connect collection contains modules that interact with your 1Passw
 ## Requirements
 - `ansible`: **>=7.x**
 - `ansible-core`: **>=2.15**
-- `python`: **>=3.8**
+- `python`: **>=3.9**
 - `1Password Connect`: **>= 1.0.0**
 
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -21,9 +21,11 @@ releases:
   2.0.0:
     changes:
       breaking_changes:
-        - generic_item - ``generate_value`` setting accepts ``on_create``, ``always``, and ``never`` (default). This enables fine-grained controls for defining when
+        - generic_item - ``generate_value`` setting accepts ``on_create``, ``always``,
+          and ``never`` (default). This enables fine-grained controls for defining when
           1Password Connect should generate a field's value. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/15)
-        - "generic_item - item options ``state: upserted`` and ``state: created`` are replaced by ``state: present``. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/15)"
+        - "generic_item - item options ``state: upserted`` and ``state: created`` are
+          replaced by ``state: present``. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/15)"
       bugfixes:
         - Makefile now uses the correct path to the testing script. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/14)
       minor_changes:
@@ -32,18 +34,24 @@ releases:
   2.1.0:
     changes:
       breaking_changes:
-        - "generic_item - if an Item of ``type: password`` has multiple ``concealed`` fields named ``password``, Ansible raises an error. (https://github.com/1Password/ansible-onepasswordconnect-collection/issues/20)"
-        - "generic_item - if an Item of ``type: password`` is created without a ``concealed`` field named ``password``, Ansible raises an error. (https://github.com/1Password/ansible-onepasswordconnect-collection/issues/20)"
-        - "generic_item - if an item of ``type: login`` has multiple ``string`` fields named ``username``, Ansible raises an error. (https://github.com/1Password/ansible-onepasswordconnect-collection/issues/20)"
+        - "generic_item - if an Item of ``type: password`` has multiple ``concealed``
+          fields named ``password``, Ansible raises an error. (https://github.com/1Password/ansible-onepasswordconnect-collection/issues/20)"
+        - "generic_item - if an Item of ``type: password`` is created without a ``concealed``
+          field named ``password``, Ansible raises an error. (https://github.com/1Password/ansible-onepasswordconnect-collection/issues/20)"
+        - "generic_item - if an item of ``type: login`` has multiple ``string`` fields
+          named ``username``, Ansible raises an error. (https://github.com/1Password/ansible-onepasswordconnect-collection/issues/20)"
       bugfixes:
         - Fix sed regex for currentVersion lookup in release tool. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/23)
         - generic_item - preserve ``notesField`` regardless of playbook parameters. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/27)
-        - generic_item - use UTF-8 string normalization while searching for fields when updating an item. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/27)
-        - module_utils - ``get_item_by_name`` client method now returns the full item response instead of the overview. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/29)
+        - generic_item - use UTF-8 string normalization while searching for fields when
+          updating an item. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/27)
+        - module_utils - ``get_item_by_name`` client method now returns the full item
+          response instead of the overview. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/29)
       minor_changes:
         - generic_item - add more supported item types (https://github.com/1Password/ansible-onepasswordconnect-collection/issues/22)
         - generic_item - default item type is now ``API_CREDENTIAL``. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/25)
-      release_summary: "This version fixes several bugs, introduces more supported item types, and improves how the module handles special fields for certain item
+      release_summary:
+        "This version fixes several bugs, introduces more supported item types, and improves how the module handles special fields for certain item
         types.\nNote there is a **breaking change** when defining an Item with ``type: login`` or ``type: password``"
     fragments:
       - 20-fix-field_purpose-assignment.yaml
@@ -59,8 +67,9 @@ releases:
     changes:
       bugfixes:
         - Replace Python 3.6+ features with backwards-compatible implementations.
-      release_summary: "This release improves compatibility with all Python runtimes supported by Ansible 2.9+.\nWe are making this change to better support customers
-        downloading this collection through RedHat's Ansible Automation Hub."
+      release_summary:
+        "This release improves compatibility with all Python runtimes supported by Ansible 2.9+.\n
+        We are making this change to better support customers downloading this collection through RedHat's Ansible Automation Hub."
     fragments:
       - 31-improve-python2-andpython3.5-compatibility.yaml
       - v2.1.1_summary.yaml
@@ -68,8 +77,10 @@ releases:
   2.2.0:
     changes:
       bugfixes:
-        - generic_item - Creating a one-time password (``OTP``) field within an item now uses the correct field type. (https://github.com/1Password/ansible-onepasswordconnect-collection/issues/46)
-        - item_info - non-unique field labels were overwriting the field values for the returned item if the field label was already in the dictionary. This is now
+        - generic_item - Creating a one-time password (``OTP``) field within an item
+          now uses the correct field type. (https://github.com/1Password/ansible-onepasswordconnect-collection/issues/46)
+        - item_info - non-unique field labels were overwriting the field values for
+          the returned item if the field label was already in the dictionary. This is now
           fixed by addding the ``flatten_fields_by_label`` option. (https://github.com/1Password/ansible-onepasswordconnect-collection/issues/34)
       minor_changes:
         - Add ``connect.field_info`` module (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/39)
@@ -78,7 +89,8 @@ releases:
     changes:
       bugfixes:
         - Add required meta/runtime.yml for Ansible Galaxy compat. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/50)
-        - Adding the ``security`` Ansible Automation Hub tag to add compliance with the Automation Hub guidelines. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/52)
+        - Adding the ``security`` Ansible Automation Hub tag to add compliance with
+          the Automation Hub guidelines. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/52)
         - Fix typo ``OP_VAULT`` into ``OP_VAULT_ID`` in the documentation. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/63)
         - module_utils - api now handles HTTP error responses. (https://github.com/1Password/ansible-onepasswordconnect-collection/issues/58)
         - module_utils - api reads the response only if the status code is ``200``. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/64)
@@ -92,7 +104,8 @@ releases:
     changes:
       bugfixes:
         - Improve error handling (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/64)
-      release_summary: This release contains small bugfixes and README changes. It also intends to go through new Ansible Automation Hub release process to keep the
+      release_summary:
+        This release contains small bugfixes and README changes. It also intends to go through new Ansible Automation Hub release process to keep the
         collection certified.
     fragments:
       - release-2.2.2.yaml

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -42,7 +42,8 @@ releases:
           named ``username``, Ansible raises an error. (https://github.com/1Password/ansible-onepasswordconnect-collection/issues/20)"
       bugfixes:
         - Fix sed regex for currentVersion lookup in release tool. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/23)
-        - generic_item - preserve ``notesField`` regardless of playbook parameters. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/27)
+        - generic_item - preserve ``notesField`` regardless of playbook parameters.
+          (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/27)
         - generic_item - use UTF-8 string normalization while searching for fields when
           updating an item. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/27)
         - module_utils - ``get_item_by_name`` client method now returns the full item
@@ -51,8 +52,8 @@ releases:
         - generic_item - add more supported item types (https://github.com/1Password/ansible-onepasswordconnect-collection/issues/22)
         - generic_item - default item type is now ``API_CREDENTIAL``. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/25)
       release_summary:
-        "This version fixes several bugs, introduces more supported item types, and improves how the module handles special fields for certain item
-        types.\nNote there is a **breaking change** when defining an Item with ``type: login`` or ``type: password``"
+        "This version fixes several bugs, introduces more supported item types, and improves how the module handles special fields for certain item types.\n
+        Note there is a **breaking change** when defining an Item with ``type: login`` or ``type: password``"
     fragments:
       - 20-fix-field_purpose-assignment.yaml
       - 22-add-more-item-types.yaml
@@ -80,8 +81,8 @@ releases:
         - generic_item - Creating a one-time password (``OTP``) field within an item
           now uses the correct field type. (https://github.com/1Password/ansible-onepasswordconnect-collection/issues/46)
         - item_info - non-unique field labels were overwriting the field values for
-          the returned item if the field label was already in the dictionary. This is now
-          fixed by addding the ``flatten_fields_by_label`` option. (https://github.com/1Password/ansible-onepasswordconnect-collection/issues/34)
+          the returned item if the field label was already in the dictionary. This is
+          now fixed by addding the ``flatten_fields_by_label`` option. (https://github.com/1Password/ansible-onepasswordconnect-collection/issues/34)
       minor_changes:
         - Add ``connect.field_info`` module (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/39)
     release_date: "2022-01-05"
@@ -93,7 +94,8 @@ releases:
           the Automation Hub guidelines. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/52)
         - Fix typo ``OP_VAULT`` into ``OP_VAULT_ID`` in the documentation. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/63)
         - module_utils - api now handles HTTP error responses. (https://github.com/1Password/ansible-onepasswordconnect-collection/issues/58)
-        - module_utils - api reads the response only if the status code is ``200``. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/64)
+        - module_utils - api reads the response only if the status code is ``200``.
+          (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/64)
     fragments:
       - 50-add-required-meta-runtime-yaml.
       - 52-add-security-AH-tag.yaml

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1,62 +1,50 @@
-ancestor: null
+---
+ancestor:
 releases:
   1.0.0:
     changes:
       bugfixes:
         - Module documentation now adheres to Ansible standards.
         - Remove Python 3.6 syntax as required by Ansible compile tests.
-      release_summary: First public release of the 1Password Ansible collection for
-        Secrets Automation.
+      release_summary: First public release of the 1Password Ansible collection for Secrets Automation.
     fragments:
       - module-documentation.yaml
       - remove-python-3.6.yaml
       - v1.0.0_summary.yaml
-    release_date: '2021-04-13'
+    release_date: "2021-04-13"
   1.0.1:
     changes:
       bugfixes:
         - Exclude the `test/` directory from the build artifact.
         - Resolve small issues with the Ansible Galaxy manifest file.
-    release_date: '2021-04-13'
+    release_date: "2021-04-13"
   2.0.0:
     changes:
       breaking_changes:
-        - generic_item - ``generate_value`` setting accepts ``on_create``, ``always``,
-          and ``never`` (default). This enables fine-grained controls for defining when
+        - generic_item - ``generate_value`` setting accepts ``on_create``, ``always``, and ``never`` (default). This enables fine-grained controls for defining when
           1Password Connect should generate a field's value. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/15)
-        - 'generic_item - item options ``state: upserted`` and ``state: created`` are
-          replaced by ``state: present``. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/15)'
+        - "generic_item - item options ``state: upserted`` and ``state: created`` are replaced by ``state: present``. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/15)"
       bugfixes:
         - Makefile now uses the correct path to the testing script. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/14)
       minor_changes:
         - module_utils - Add support for ``API_CREDENTIAL`` item type. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/17)
-    release_date: '2021-05-25'
+    release_date: "2021-05-25"
   2.1.0:
     changes:
       breaking_changes:
-        - 'generic_item - if an Item of ``type: password`` has multiple ``concealed``
-          fields named ``password``, Ansible raises an error. (https://github.com/1Password/ansible-onepasswordconnect-collection/issues/20)'
-        - 'generic_item - if an Item of ``type: password`` is created without a ``concealed``
-          field named ``password``, Ansible raises an error. (https://github.com/1Password/ansible-onepasswordconnect-collection/issues/20)'
-        - 'generic_item - if an item of ``type: login`` has multiple ``string`` fields
-          named ``username``, Ansible raises an error. (https://github.com/1Password/ansible-onepasswordconnect-collection/issues/20)'
+        - "generic_item - if an Item of ``type: password`` has multiple ``concealed`` fields named ``password``, Ansible raises an error. (https://github.com/1Password/ansible-onepasswordconnect-collection/issues/20)"
+        - "generic_item - if an Item of ``type: password`` is created without a ``concealed`` field named ``password``, Ansible raises an error. (https://github.com/1Password/ansible-onepasswordconnect-collection/issues/20)"
+        - "generic_item - if an item of ``type: login`` has multiple ``string`` fields named ``username``, Ansible raises an error. (https://github.com/1Password/ansible-onepasswordconnect-collection/issues/20)"
       bugfixes:
         - Fix sed regex for currentVersion lookup in release tool. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/23)
-        - generic_item - preserve ``notesField`` regardless of playbook parameters.
-          (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/27)
-        - generic_item - use UTF-8 string normalization while searching for fields when
-          updating an item. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/27)
-        - module_utils - ``get_item_by_name`` client method now returns the full item
-          response instead of the overview. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/29)
+        - generic_item - preserve ``notesField`` regardless of playbook parameters. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/27)
+        - generic_item - use UTF-8 string normalization while searching for fields when updating an item. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/27)
+        - module_utils - ``get_item_by_name`` client method now returns the full item response instead of the overview. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/29)
       minor_changes:
         - generic_item - add more supported item types (https://github.com/1Password/ansible-onepasswordconnect-collection/issues/22)
         - generic_item - default item type is now ``API_CREDENTIAL``. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/25)
-      release_summary: 'This version fixes several bugs, introduces more supported
-        item types, and improves how the module handles special fields for certain
-        item types.
-
-        Note there is a **breaking change** when defining an Item with ``type: login``
-        or ``type: password``'
+      release_summary: "This version fixes several bugs, introduces more supported item types, and improves how the module handles special fields for certain item
+        types.\nNote there is a **breaking change** when defining an Item with ``type: login`` or ``type: password``"
     fragments:
       - 20-fix-field_purpose-assignment.yaml
       - 22-add-more-item-types.yaml
@@ -66,68 +54,58 @@ releases:
       - 27-use-utf8-normalization.yaml
       - 29-get-item-by-name-return-full-item.yaml
       - v2.1.0_summary.yaml
-    release_date: '2021-06-23'
+    release_date: "2021-06-23"
   2.1.1:
     changes:
       bugfixes:
         - Replace Python 3.6+ features with backwards-compatible implementations.
-      release_summary: 'This release improves compatibility with all Python runtimes
-        supported by Ansible 2.9+.
-
-        We are making this change to better support customers downloading this collection
-        through RedHat''s Ansible Automation Hub.'
+      release_summary: "This release improves compatibility with all Python runtimes supported by Ansible 2.9+.\nWe are making this change to better support customers
+        downloading this collection through RedHat's Ansible Automation Hub."
     fragments:
       - 31-improve-python2-andpython3.5-compatibility.yaml
       - v2.1.1_summary.yaml
-    release_date: '2021-06-25'
+    release_date: "2021-06-25"
   2.2.0:
     changes:
       bugfixes:
-        - generic_item - Creating a one-time password (``OTP``) field within an item
-          now uses the correct field type. (https://github.com/1Password/ansible-onepasswordconnect-collection/issues/46)
-        - item_info - non-unique field labels were overwriting the field values for
-          the returned item if the field label was already in the dictionary. This is
-          now fixed by addding the ``flatten_fields_by_label`` option. (https://github.com/1Password/ansible-onepasswordconnect-collection/issues/34)
+        - generic_item - Creating a one-time password (``OTP``) field within an item now uses the correct field type. (https://github.com/1Password/ansible-onepasswordconnect-collection/issues/46)
+        - item_info - non-unique field labels were overwriting the field values for the returned item if the field label was already in the dictionary. This is now
+          fixed by addding the ``flatten_fields_by_label`` option. (https://github.com/1Password/ansible-onepasswordconnect-collection/issues/34)
       minor_changes:
         - Add ``connect.field_info`` module (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/39)
-    release_date: '2022-01-05'
+    release_date: "2022-01-05"
   2.2.1:
     changes:
       bugfixes:
         - Add required meta/runtime.yml for Ansible Galaxy compat. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/50)
-        - Adding the ``security`` Ansible Automation Hub tag to add compliance with
-          the Automation Hub guidelines. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/52)
+        - Adding the ``security`` Ansible Automation Hub tag to add compliance with the Automation Hub guidelines. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/52)
         - Fix typo ``OP_VAULT`` into ``OP_VAULT_ID`` in the documentation. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/63)
         - module_utils - api now handles HTTP error responses. (https://github.com/1Password/ansible-onepasswordconnect-collection/issues/58)
-        - module_utils - api reads the response only if the status code is ``200``.
-          (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/64)
+        - module_utils - api reads the response only if the status code is ``200``. (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/64)
     fragments:
       - 50-add-required-meta-runtime-yaml.
       - 52-add-security-AH-tag.yaml
       - 58-bad-request-using-item-field-name.yaml
       - 64_handle_response_better.yaml
-    release_date: '2022-08-30'
+    release_date: "2022-08-30"
   2.2.2:
     changes:
       bugfixes:
         - Improve error handling (https://github.com/1Password/ansible-onepasswordconnect-collection/pull/64)
-      release_summary: This release contains small bugfixes and README changes. It
-        also intends to go through new Ansible Automation Hub release process to keep
-        the collection certified.
+      release_summary: This release contains small bugfixes and README changes. It also intends to go through new Ansible Automation Hub release process to keep the
+        collection certified.
     fragments:
       - release-2.2.2.yaml
-    release_date: '2023-09-20'
+    release_date: "2023-09-20"
   2.2.3:
     changes:
-      release_summary: This release is to address the issues found durin Automation
-        Hub release process
+      release_summary: This release is to address the issues found durin Automation Hub release process
     fragments:
       - release-v2.2.3.yml
-    release_date: '2023-09-22'
+    release_date: "2023-09-22"
   2.2.4:
     changes:
-      release_summary: This release is to update documentation and pipelines due to
-        ansible-core@2.13 end of life.
+      release_summary: This release is to update documentation and pipelines due to ansible-core@2.13 end of life.
     fragments:
       - release-v2.2.4.yaml
-    release_date: '2023-11-20'
+    release_date: "2023-11-20"

--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -1,3 +1,4 @@
+---
 changelog_filename_template: ../CHANGELOG.rst
 changelog_filename_version_depth: 0
 changes_file: changelog.yaml
@@ -11,14 +12,14 @@ prelude_section_name: release_summary
 prelude_section_title: Release Summary
 sanitize_changelog: true
 sections:
- - ['major_changes', 'Major Changes']
- - ['minor_changes', 'Minor Changes']
- - ['breaking_changes', 'Breaking Changes / Porting Guide']
- - ['deprecated_features', 'Deprecated Features']
- - ['removed_features', 'Removed Features (previously deprecated)']
- - ['security_fixes', 'Security Fixes']
- - ['bugfixes', 'Bugfixes']
- - ['known_issues', 'Known Issues']
+  - [major_changes, Major Changes]
+  - [minor_changes, Minor Changes]
+  - [breaking_changes, Breaking Changes / Porting Guide]
+  - [deprecated_features, Deprecated Features]
+  - [removed_features, Removed Features (previously deprecated)]
+  - [security_fixes, Security Fixes]
+  - [bugfixes, Bugfixes]
+  - [known_issues, Known Issues]
 title: onepassword.connect
 trivial_section_name: trivial
 use_fqcn: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.14.0"
+requires_ansible: ">=2.15.0"

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -1,2 +1,3 @@
+---
 modules:
   python_requires: ~=3.8

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -1,3 +1,3 @@
 ---
 modules:
-  python_requires: ~=3.8
+  python_requires: ~=3.9


### PR DESCRIPTION
This PR makes the following changes:
- Set Ansible Core `2.15` as the minimum required version
- Set Python `3.9` as the minimum required Python version.
- Upgrade `ansible-lint` to `6.22.2` and adjust code based on new lint rules.
- Remove Ansible Core 2.14 from the codebase and pipeline testing matrix.
- Add Python `3.12` as a supported version since it's supported with Ansible Core `2.16`.

Closes #89.