### PR TITLE
ansible core 2.16 and pyton 3.12 update

### DIFF
--- a/.github/workflows/ansible-tests.yml
+++ b/.github/workflows/ansible-tests.yml
@@ -7,10 +7,10 @@ on:
       - "main"
 
 env:
-  PYTHON_VERSION: "3.10"
+  PYTHON_VERSION: "3.12"
   # arbitrarily choosing the latest stable version to run ansible-test units
   # running 'ansible-test units' for each ansible+python version isn't necessary
-  ANSIBLE_FOR_UNIT_TESTS: "2.15"
+  ANSIBLE_FOR_UNIT_TESTS: "2.16"
   # defines where ansible will look for the collection
   # must be a sub-directory of ansible_collections/
   COLLECTION_PATH: ansible_collections/onepassword/connect
@@ -21,13 +21,15 @@ jobs:
     strategy:
       # https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
       matrix:
-        ansible: ["2.15", "2.16"]
-        python: ["3.9", "3.10", "3.11", "3.12"]
+        ansible: ["2.16", "2.17", "2.18"]
+        python: ["3.10", "3.11", "3.12", "3.13"]
         exclude:
           - ansible: "2.16"
-            python: "3.9"
-          - ansible: "2.15"
-            python: "3.12"
+            python: "3.13"
+          - ansible: "2.17"
+            python: "3.13"
+          - ansible: "2.18"
+            python: "3.10"
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -1,9 +1,9 @@
 # Contributing
 
-Thank you taking the time to improve the 1Password Ansible collection! 
+Thank you taking the time to improve the 1Password Ansible collection!
 
-After reading this document, you will: 
-- have set up a development environment; 
+After reading this document, you will:
+- have set up a development environment;
 - know how to file issues;
 - understand the pull request process.
 
@@ -18,10 +18,10 @@ This collection requires **Python v3.9 or greater**. If you don't have Python in
 
 
 Current Ansible-core and Ansible version supported:
-- `ansible-core`: **>=2.15**
-- `ansible`: **>=7.x**
+- `ansible-core`: **>=2.16.0**
+- `ansible` (community package): **>=9.x** (includes ansible-core 2.16)
 
-We recommend installing Ansible in a `virtualenv` created specifically for this project. 
+We recommend installing Ansible in a `virtualenv` created specifically for this project.
 
 #### Install Ansible via virtualenv
 
@@ -29,7 +29,7 @@ We recommend installing Ansible in a `virtualenv` created specifically for this 
 python3 -m venv <path_to_venv>/onepassword_ansible
 source <path_to_venv>/onepassword_ansible activate
 
-pip3 install 'ansible-core==2.15.*' 'ansible>=7.x'
+pip3 install 'ansible-core>=2.16,<2.17' 'ansible>=9,<10'
 ```
 
 ### Clone the Repo
@@ -50,8 +50,8 @@ cd ~/onepassword/ansible_collections/onepassword
 git clone git@github.com:1Password/ansible-onepasswordconnect-collection.git connect
 cd connect
 
-# Extend Ansible's collection lookup path 
-# to first look for collections inside ~/onepassword/ansible_collections/... 
+# Extend Ansible's collection lookup path
+# to first look for collections inside ~/onepassword/ansible_collections/...
 export ANSIBLE_COLLECTIONS_PATHS=~/onepassword:$ANSIBLE_COLLECTIONS_PATHS
 
 # Verify - you should see docs for the `generic_item` module in your terminal
@@ -66,7 +66,7 @@ We run our tests using Docker images. See [tests/README.md](tests/README.md) for
 
 ## Filing Issues
 
-We welcome you to file bug reports and feature requests through GitHub issues. 
+We welcome you to file bug reports and feature requests through GitHub issues.
 
 There are templates for issues and feature requests, but if the issue does not fall into either category, please use an empty issue and be as specific as possible.
 

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -14,7 +14,7 @@ After reading this document, you will:
 
 > If you have already installed a supported version of Ansible, you can skip to the [Clone the Repo](#clone-the-repo) step.
 
-This collection requires **Python v3.9 or greater**. If you don't have Python installed, consider using [pyenv](https://github.com/pyenv/pyenv) to install the supported Python runtime.
+This collection requires **Python v3.10 or greater**. If you don't have Python installed, consider using [pyenv](https://github.com/pyenv/pyenv) to install the supported Python runtime.
 
 
 Current Ansible-core and Ansible version supported:

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ The 1Password Connect collection contains modules that interact with your 1Passw
 
 ## Requirements
 
-- `ansible`: **>=7.x**
-- `ansible-core`: **>=2.15**
-- `python`: **>=3.9**
+- `ansible` (community package): **>=9.x** (includes ansible-core 2.16)
+- `ansible-core`: **>=2.16.0**
+- `python`: **>=3.10**
 - `1Password Connect`: **>= 1.0.0**
 
 ## ✨ Get started

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.15.0"
+requires_ansible: ">=2.16.0"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -38,7 +38,7 @@ PATH_TO_PACKAGES="$(git rev-parse --show-toplevel)"
 DOCKER_IMG="default"
 
 # Minimum python version that is compatible with ansible versions in test matrix
-PYTHON_VERSION="3.9"
+PYTHON_VERSION="3.12"
 
 function _cleanup() {
   rm -r "${TMP_DIR_PATH}"

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -1,3 +1,3 @@
 ---
 modules:
-  python_requires: ~=3.9
+  python_requires: ~=3.10


### PR DESCRIPTION
## What's Changed
This PR updates the collection to match Red Hat Automation Hub’s 2026 requirements.

- Bumped minimum Ansible Core support to >=2.16.0
- Added/aligned Python 3.12 coverage in CI and local test tooling
- Updated docs so requirements are consistent across the repo

Ran a playbook against a live Connect instance; create, read, update, and delete item flows all succeeded.
