### PR TITLE
Fix release-pr workflow action pin

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Create Pull Request via API
         id: post_pr
-        uses: octokit/request-action@v3
+        uses: octokit/request-action@v3.0.0
         with:
           route: POST /repos/${{ github.repository }}/pulls
           title: ${{ format('Prepare Release - v{0}', steps.get_version.outputs.version) }}


### PR DESCRIPTION
Pins octokit/request-action to v3.0.0 because v3 is not a published ref, which caused the “Open Release PR” workflow to fail when resolving the action.