### PR TITLE
Update collection metadata and README for Automation Hub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,3 @@
-[//]: # (START/LATEST)
-# Latest
-
-## Features
-  * A user-friendly description of a new feature. {issue-number}
-
-## Fixes
- * A user-friendly description of a fix. {issue-number}
-
-## Security
- * A user-friendly description of a security fix. {issue-number}
-
----
-
 [//]: # (START/v2.4.0)
 # v2.4.0
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ tasks:
 
 ### 📄 Usage
 
-Refer to the [Usage Guide](https://github.com/1Password/ansible-onepasswordconnect-collection/blob/main/USAGEGUIDE.md) for documentation for example usage.
+Refer to the [Usage Guide](https://github.com/1Password/ansible-onepasswordconnect-collection/blob/main/USAGEGUIDE.md) for usage examples.
 
 ## 📝 Changelog
 

--- a/README.md
+++ b/README.md
@@ -52,16 +52,25 @@ tasks:
 
 ### 📄 Usage
 
-Refer to the [Usage Guide](USAGEGUIDE.md) for documentation for example usage.
+Refer to the [Usage Guide](https://github.com/1Password/ansible-onepasswordconnect-collection/blob/main/USAGEGUIDE.md) for documentation for example usage.
+
+## 📝 Changelog
+
+Release notes for each version are documented in the [Changelog](https://github.com/1Password/ansible-onepasswordconnect-collection/blob/main/CHANGELOG.md).
 
 ## 💙 Community & Support
 
 - File an [issue](https://github.com/1Password/ansible-onepasswordconnect-collection/issues) for bugs and feature requests.
 - Join the [Developer Slack workspace](https://developer.1password.com/joinslack).
 - Subscribe to the [Developer Newsletter](https://1password.com/dev-subscribe/).
+- **Red Hat customers:** Open a support case through the "Create issue" link on the collection's [Automation Hub](https://console.redhat.com/ansible/automation-hub/collections/published/onepassword/connect/details) page.
 
 ## 🔐 Security
 
 1Password requests you practice responsible disclosure if you discover a vulnerability.
 
 Please file requests by sending an email to bugbounty@agilebits.com.
+
+## 📜 License
+
+This collection is licensed under [GPL-3.0-or-later](https://github.com/1Password/ansible-onepasswordconnect-collection/blob/main/LICENSE.md).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -15,6 +15,8 @@ authors:
 description: Modules for managing and reading 1Password Vaults with 1Password Connect.
 
 license_file: LICENSE.md
+license:
+  - GPL-3.0-or-later
 
 tags: [security, onepassword, secrets, onepasswordconnect, connect]
 dependencies: {}
@@ -31,4 +33,4 @@ issues: https://github.com/1Password/ansible-onepasswordconnect-collection/issue
 
 # A list of file glob-like patterns used to filter any files or directories that should not be included in the build
 # artifact.
-build_ignore: [scripts, .venv, venv, .*, tests]
+build_ignore: [scripts, .venv, venv, .*, tests, dist, Makefile]


### PR DESCRIPTION
## Summary

Our most recent release was approved by Red Hat for Automation Hub, but the certification team reached out with a set of requested updates to apply before our next release. This PR addresses each of those items so we land the next release in good standing.

### Changes
Changes that were requested: 

- **License declaration** — Declare `GPL-3.0-or-later` under the `license` key in `galaxy.yml` and state the license type in the README.
- **Relative link in README** — Replace the relative `USAGEGUIDE.md` link with an absolute GitHub URL so it resolves on Automation Hub.
- **Changelog reference in README** — Add a Changelog section linking to `CHANGELOG.md`.
- **Support section** — Direct Red Hat customers to open support cases through the Automation Hub "Create issue" link.
- **Changelog cleanup** — Remove the placeholder template block at the top of `CHANGELOG.md`.
- **Lean tarball** — Add `dist/` and `Makefile` to `build_ignore` in `galaxy.yml`.
  

There is no logic changes here so no testing needed.